### PR TITLE
adding oxygen correction to arod

### DIFF
--- a/variables.yaml
+++ b/variables.yaml
@@ -148,6 +148,8 @@ netcdf_variables:
     standard_name: mole_concentration_of_dissolved_molecular_oxygen_in_sea_water
     units:        umol l-1
     coordinates:   time depth latitude longitude
+    correct_oxygen: "True"
+    reference_salinity: "0"
 
   temperature_oxygen:
     source:  AROD_FT_TEMP


### PR DESCRIPTION
Bastien pointed out in slack that the oxygen values produced by AROD are incorrect as they do not correct for salinity. This is being fixed in pyglider as a PR https://github.com/c-proof/pyglider/pull/43

Once merged, a couple of keywords in the yaml included in this PR will trigger the salinity correction in pyglider