### PR TITLE
change all sea_name to baltic

### DIFF
--- a/meta.yaml
+++ b/meta.yaml
@@ -24,6 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
+  sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: <glider name>
   glider_serial: <glider number>
@@ -42,5 +43,3 @@ metadata:
   project: <project name>
   project_url: <project url>
   summary: <mission summary>
-  # Examples: Skagerrak, Kattegatt, Baltic, Gulf of Bothnia, Gulf of Finland, Gulf of Riga
-  sea_name: <sea name e.g. Baltic>

--- a/mission_yaml/SEA44_M25.yml
+++ b/mission_yaml/SEA44_M25.yml
@@ -24,7 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
-sea_name: Baltic
+  sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Martorn
   glider_serial: "44"

--- a/mission_yaml/SEA44_M25.yml
+++ b/mission_yaml/SEA44_M25.yml
@@ -24,6 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
+sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Martorn
   glider_serial: "44"
@@ -42,8 +43,6 @@ metadata:
   project: SAMBA
   project_url: https://voiceoftheocean.org/samba-smart-autonomous-monitoring-of-the-baltic-sea/
   summary: ' Part of SAMBA continuous monitoring'
-  # Examples: Skagerrak, Kattegatt, Baltic, Gulf of Bothnia, Gulf of Finland, Gulf of Riga
-  sea_name: Skagerrak
 
 glider_devices:
   altimeter:

--- a/mission_yaml/SEA44_M28.yml
+++ b/mission_yaml/SEA44_M28.yml
@@ -24,7 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
-sea_name: Baltic
+  sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Martorn
   glider_serial: "44"

--- a/mission_yaml/SEA44_M28.yml
+++ b/mission_yaml/SEA44_M28.yml
@@ -24,6 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
+sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Martorn
   glider_serial: "44"
@@ -42,8 +43,6 @@ metadata:
   project: SAMBA
   project_url: https://voiceoftheocean.org/samba-smart-autonomous-monitoring-of-the-baltic-sea/
   summary: ' Part of SAMBA continuous monitoring'
-  # Examples: Skagerrak, Kattegatt, Baltic, Gulf of Bothnia, Gulf of Finland, Gulf of Riga
-  sea_name: Skagerrak
 
 glider_devices:
   altimeter:

--- a/mission_yaml/SEA44_M29.yml
+++ b/mission_yaml/SEA44_M29.yml
@@ -24,7 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
-sea_name: Baltic
+  sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Martorn
   glider_serial: "44"

--- a/mission_yaml/SEA44_M29.yml
+++ b/mission_yaml/SEA44_M29.yml
@@ -24,6 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
+sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Martorn
   glider_serial: "44"
@@ -42,8 +43,6 @@ metadata:
   project: SAMBA
   project_url: https://voiceoftheocean.org/samba-smart-autonomous-monitoring-of-the-baltic-sea/
   summary: ' Part of SAMBA continuous monitoring'
-  # Examples: Skagerrak, Kattegatt, Baltic, Gulf of Bothnia, Gulf of Finland, Gulf of Riga
-  sea_name: Skagerrak
 
 glider_devices:
   altimeter:

--- a/mission_yaml/SEA44_M32.yml
+++ b/mission_yaml/SEA44_M32.yml
@@ -24,7 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
-sea_name: Baltic
+  sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Martorn
   glider_serial: "44"

--- a/mission_yaml/SEA44_M32.yml
+++ b/mission_yaml/SEA44_M32.yml
@@ -24,6 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
+sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Martorn
   glider_serial: "44"
@@ -42,8 +43,6 @@ metadata:
   project: SAMBA
   project_url: https://voiceoftheocean.org/samba-smart-autonomous-monitoring-of-the-baltic-sea/
   summary: ' Part of SAMBA continuous monitoring'
-  # Examples: Skagerrak, Kattegatt, Baltic, Gulf of Bothnia, Gulf of Finland, Gulf of Riga
-  sea_name: Skagerrak
 
 glider_devices:
   altimeter:

--- a/mission_yaml/SEA44_M33.yml
+++ b/mission_yaml/SEA44_M33.yml
@@ -24,7 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
-sea_name: Baltic
+  sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Martorn
   glider_serial: "44"

--- a/mission_yaml/SEA44_M33.yml
+++ b/mission_yaml/SEA44_M33.yml
@@ -24,6 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
+sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Martorn
   glider_serial: "44"
@@ -42,8 +43,6 @@ metadata:
   project: SAMBA
   project_url: https://voiceoftheocean.org/samba-smart-autonomous-monitoring-of-the-baltic-sea/
   summary: ' Part of SAMBA continuous monitoring'
-  # Examples: Skagerrak, Kattegatt, Baltic, Gulf of Bothnia, Gulf of Finland, Gulf of Riga
-  sea_name: Skagerrak
 
 glider_devices:
   altimeter:

--- a/mission_yaml/SEA44_M34.yml
+++ b/mission_yaml/SEA44_M34.yml
@@ -24,7 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
-sea_name: Baltic
+  sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Martorn
   glider_serial: "44"

--- a/mission_yaml/SEA44_M34.yml
+++ b/mission_yaml/SEA44_M34.yml
@@ -24,6 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
+sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Martorn
   glider_serial: "44"
@@ -42,8 +43,6 @@ metadata:
   project: SAMBA
   project_url: https://voiceoftheocean.org/samba-smart-autonomous-monitoring-of-the-baltic-sea/
   summary: ' Part of SAMBA continuous monitoring'
-  # Examples: Skagerrak, Kattegatt, Baltic, Gulf of Bothnia, Gulf of Finland, Gulf of Riga
-  sea_name: Skagerrak
 
 glider_devices:
   altimeter:

--- a/mission_yaml/SEA44_M35.yml
+++ b/mission_yaml/SEA44_M35.yml
@@ -24,7 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
-sea_name: Baltic
+  sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Martorn
   glider_serial: "44"

--- a/mission_yaml/SEA44_M35.yml
+++ b/mission_yaml/SEA44_M35.yml
@@ -24,6 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
+sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Martorn
   glider_serial: "44"
@@ -42,8 +43,6 @@ metadata:
   project: SAMBA
   project_url: https://voiceoftheocean.org/samba-smart-autonomous-monitoring-of-the-baltic-sea/
   summary: ' Part of SAMBA continuous monitoring'
-  # Examples: Skagerrak, Kattegatt, Baltic, Gulf of Bothnia, Gulf of Finland, Gulf of Riga
-  sea_name: Skagerrak
 
 glider_devices:
   altimeter:

--- a/mission_yaml/SEA44_M40.yml
+++ b/mission_yaml/SEA44_M40.yml
@@ -24,7 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
-sea_name: Baltic
+  sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Martorn
   glider_serial: "44"

--- a/mission_yaml/SEA44_M40.yml
+++ b/mission_yaml/SEA44_M40.yml
@@ -24,6 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
+sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Martorn
   glider_serial: "44"
@@ -42,8 +43,6 @@ metadata:
   project: SAMBA
   project_url: https://voiceoftheocean.org/samba-smart-autonomous-monitoring-of-the-baltic-sea/
   summary: ' Part of SAMBA continuous monitoring'
-  # Examples: Skagerrak, Kattegatt, Baltic, Gulf of Bothnia, Gulf of Finland, Gulf of Riga
-  sea_name: Baltic
 
 glider_devices:
   altimeter:

--- a/mission_yaml/SEA44_M45.yml
+++ b/mission_yaml/SEA44_M45.yml
@@ -24,7 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
-sea_name: Baltic
+  sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Martorn
   glider_serial: "44"

--- a/mission_yaml/SEA44_M45.yml
+++ b/mission_yaml/SEA44_M45.yml
@@ -24,6 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
+sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Martorn
   glider_serial: "44"
@@ -42,8 +43,6 @@ metadata:
   project: SAMBA
   project_url: https://voiceoftheocean.org/samba-smart-autonomous-monitoring-of-the-baltic-sea/
   summary: ' Part of SAMBA continuous monitoring'
-  # Examples: Skagerrak, Kattegatt, Baltic, Gulf of Bothnia, Gulf of Finland, Gulf of Riga
-  sea_name: Skagerrak
 
 glider_devices:
   altimeter:

--- a/mission_yaml/SEA44_M46.yml
+++ b/mission_yaml/SEA44_M46.yml
@@ -24,7 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
-sea_name: Baltic
+  sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Martorn
   glider_serial: "44"

--- a/mission_yaml/SEA44_M46.yml
+++ b/mission_yaml/SEA44_M46.yml
@@ -24,6 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
+sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Martorn
   glider_serial: "44"
@@ -42,8 +43,6 @@ metadata:
   project: SAMBA
   project_url: https://voiceoftheocean.org/samba-smart-autonomous-monitoring-of-the-baltic-sea/
   summary: ' Part of SAMBA continuous monitoring'
-  # Examples: Skagerrak, Kattegatt, Baltic, Gulf of Bothnia, Gulf of Finland, Gulf of Riga
-  sea_name: Skagerrak
 
 glider_devices:
   altimeter:

--- a/mission_yaml/SEA44_M48.yml
+++ b/mission_yaml/SEA44_M48.yml
@@ -24,7 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
-sea_name: Baltic
+  sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Martorn
   glider_serial: "44"

--- a/mission_yaml/SEA44_M48.yml
+++ b/mission_yaml/SEA44_M48.yml
@@ -24,6 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
+sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Martorn
   glider_serial: "44"
@@ -42,8 +43,6 @@ metadata:
   project: SAMBA
   project_url: https://voiceoftheocean.org/samba-smart-autonomous-monitoring-of-the-baltic-sea/
   summary: ' Part of SAMBA continuous monitoring'
-  # Examples: Skagerrak, Kattegatt, Baltic, Gulf of Bothnia, Gulf of Finland, Gulf of Riga
-  sea_name: Baltic
 
 glider_devices:
   altimeter:

--- a/mission_yaml/SEA45_M33.yml
+++ b/mission_yaml/SEA45_M33.yml
@@ -24,7 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
-sea_name: Baltic
+  sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Kvanne
   glider_serial: "45"

--- a/mission_yaml/SEA45_M33.yml
+++ b/mission_yaml/SEA45_M33.yml
@@ -24,6 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
+sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Kvanne
   glider_serial: "45"
@@ -42,8 +43,6 @@ metadata:
   project: SAMBA
   project_url: https://voiceoftheocean.org/samba-smart-autonomous-monitoring-of-the-baltic-sea/
   summary: ' Part of SAMBA continuous monitoring'
-  # Examples: Skagerrak, Kattegatt, Baltic, Gulf of Bothnia, Gulf of Finland, Gulf of Riga
-  sea_name: Skagerrak
 
 
 glider_devices:

--- a/mission_yaml/SEA45_M36.yml
+++ b/mission_yaml/SEA45_M36.yml
@@ -24,7 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
-sea_name: Baltic
+  sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Kvanne
   glider_serial: "45"

--- a/mission_yaml/SEA45_M36.yml
+++ b/mission_yaml/SEA45_M36.yml
@@ -24,6 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
+sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Kvanne
   glider_serial: "45"
@@ -42,8 +43,6 @@ metadata:
   project: SAMBA
   project_url: https://voiceoftheocean.org/samba-smart-autonomous-monitoring-of-the-baltic-sea/
   summary: ' Part of SAMBA continuous monitoring'
-  # Examples: Skagerrak, Kattegatt, Baltic, Gulf of Bothnia, Gulf of Finland, Gulf of Riga
-  sea_name: Skagerrak
 
 
 glider_devices:

--- a/mission_yaml/SEA45_M37.yml
+++ b/mission_yaml/SEA45_M37.yml
@@ -24,7 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
-sea_name: Baltic
+  sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Kvanne
   glider_serial: "45"

--- a/mission_yaml/SEA45_M37.yml
+++ b/mission_yaml/SEA45_M37.yml
@@ -24,6 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
+sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Kvanne
   glider_serial: "45"
@@ -42,8 +43,6 @@ metadata:
   project: SAMBA
   project_url: https://voiceoftheocean.org/samba-smart-autonomous-monitoring-of-the-baltic-sea/
   summary: ' Part of SAMBA continuous monitoring'
-  # Examples: Skagerrak, Kattegatt, Baltic, Gulf of Bothnia, Gulf of Finland, Gulf of Riga
-  sea_name: Skagerrak
 
 
 glider_devices:

--- a/mission_yaml/SEA45_M41.yml
+++ b/mission_yaml/SEA45_M41.yml
@@ -24,7 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
-sea_name: Baltic
+  sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Kvanne
   glider_serial: "45"

--- a/mission_yaml/SEA45_M41.yml
+++ b/mission_yaml/SEA45_M41.yml
@@ -24,6 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
+sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Kvanne
   glider_serial: "45"
@@ -42,8 +43,6 @@ metadata:
   project: SAMBA
   project_url: https://voiceoftheocean.org/samba-smart-autonomous-monitoring-of-the-baltic-sea/
   summary: ' Part of SAMBA continuous monitoring'
-  # Examples: Skagerrak, Kattegatt, Baltic, Gulf of Bothnia, Gulf of Finland, Gulf of Riga
-  sea_name: Skagerrak
 
 
 glider_devices:

--- a/mission_yaml/SEA45_M42.yml
+++ b/mission_yaml/SEA45_M42.yml
@@ -24,7 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
-sea_name: Baltic
+  sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Kvanne
   glider_serial: "45"

--- a/mission_yaml/SEA45_M42.yml
+++ b/mission_yaml/SEA45_M42.yml
@@ -24,6 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
+sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Kvanne
   glider_serial: "45"
@@ -42,8 +43,6 @@ metadata:
   project: SAMBA
   project_url: https://voiceoftheocean.org/samba-smart-autonomous-monitoring-of-the-baltic-sea/
   summary: ' Part of SAMBA continuous monitoring'
-  # Examples: Skagerrak, Kattegatt, Baltic, Gulf of Bothnia, Gulf of Finland, Gulf of Riga
-  sea_name: Skagerrak
 
 
 glider_devices:

--- a/mission_yaml/SEA45_M43.yml
+++ b/mission_yaml/SEA45_M43.yml
@@ -24,7 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
-sea_name: Baltic
+  sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Kvanne
   glider_serial: "45"

--- a/mission_yaml/SEA45_M43.yml
+++ b/mission_yaml/SEA45_M43.yml
@@ -24,6 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
+sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Kvanne
   glider_serial: "45"
@@ -42,8 +43,6 @@ metadata:
   project: SAMBA
   project_url: https://voiceoftheocean.org/samba-smart-autonomous-monitoring-of-the-baltic-sea/
   summary: ' Part of SAMBA continuous monitoring'
-  # Examples: Skagerrak, Kattegatt, Baltic, Gulf of Bothnia, Gulf of Finland, Gulf of Riga
-  sea_name: Skagerrak
 
 
 glider_devices:

--- a/mission_yaml/SEA45_M44.yml
+++ b/mission_yaml/SEA45_M44.yml
@@ -24,7 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
-sea_name: Baltic
+  sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Kvanne
   glider_serial: "45"

--- a/mission_yaml/SEA45_M44.yml
+++ b/mission_yaml/SEA45_M44.yml
@@ -24,6 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
+sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Kvanne
   glider_serial: "45"
@@ -42,8 +43,6 @@ metadata:
   project: SAMBA
   project_url: https://voiceoftheocean.org/samba-smart-autonomous-monitoring-of-the-baltic-sea/
   summary: ' Part of SAMBA continuous monitoring'
-  # Examples: Skagerrak, Kattegatt, Baltic, Gulf of Bothnia, Gulf of Finland, Gulf of Riga
-  sea_name: Skagerrak
 
 
 glider_devices:

--- a/mission_yaml/SEA45_M45.yml
+++ b/mission_yaml/SEA45_M45.yml
@@ -24,7 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
-sea_name: Baltic
+  sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Kvanne
   glider_serial: "45"

--- a/mission_yaml/SEA45_M45.yml
+++ b/mission_yaml/SEA45_M45.yml
@@ -24,6 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
+sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Kvanne
   glider_serial: "45"
@@ -42,8 +43,6 @@ metadata:
   project: SAMBA
   project_url: https://voiceoftheocean.org/samba-smart-autonomous-monitoring-of-the-baltic-sea/
   summary: ' Part of SAMBA continuous monitoring'
-  # Examples: Skagerrak, Kattegatt, Baltic, Gulf of Bothnia, Gulf of Finland, Gulf of Riga
-  sea_name: Skagerrak
 
 
 glider_devices:

--- a/mission_yaml/SEA45_M48.yml
+++ b/mission_yaml/SEA45_M48.yml
@@ -24,7 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
-sea_name: Baltic
+  sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Kvanne
   glider_serial: "45"

--- a/mission_yaml/SEA45_M48.yml
+++ b/mission_yaml/SEA45_M48.yml
@@ -24,6 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
+sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Kvanne
   glider_serial: "45"
@@ -42,8 +43,6 @@ metadata:
   project: SAMBA
   project_url: https://voiceoftheocean.org/samba-smart-autonomous-monitoring-of-the-baltic-sea/
   summary: ' Part of SAMBA continuous monitoring'
-  # Examples: Skagerrak, Kattegatt, Baltic, Gulf of Bothnia, Gulf of Finland, Gulf of Riga
-  sea_name: Baltic
 
 
 glider_devices:

--- a/mission_yaml/SEA45_M50.yml
+++ b/mission_yaml/SEA45_M50.yml
@@ -24,7 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
-sea_name: Baltic
+  sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Kvanne
   glider_serial: "45"

--- a/mission_yaml/SEA45_M50.yml
+++ b/mission_yaml/SEA45_M50.yml
@@ -24,6 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
+sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Kvanne
   glider_serial: "45"
@@ -42,8 +43,6 @@ metadata:
   project: SAMBA
   project_url: https://voiceoftheocean.org/samba-smart-autonomous-monitoring-of-the-baltic-sea/
   summary: ' Part of SAMBA continuous monitoring'
-  # Examples: Skagerrak, Kattegatt, Baltic, Gulf of Bothnia, Gulf of Finland, Gulf of Riga
-  sea_name: Skagerrak
 
 
 glider_devices:

--- a/mission_yaml/SEA45_M51.yml
+++ b/mission_yaml/SEA45_M51.yml
@@ -24,7 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
-sea_name: Baltic
+  sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Kvanne
   glider_serial: "45"

--- a/mission_yaml/SEA45_M51.yml
+++ b/mission_yaml/SEA45_M51.yml
@@ -24,6 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
+sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Kvanne
   glider_serial: "45"
@@ -42,8 +43,6 @@ metadata:
   project: SAMBA
   project_url: https://voiceoftheocean.org/samba-smart-autonomous-monitoring-of-the-baltic-sea/
   summary: ' Part of SAMBA continuous monitoring'
-  # Examples: Skagerrak, Kattegatt, Baltic, Gulf of Bothnia, Gulf of Finland, Gulf of Riga
-  sea_name: Skagerrak
 
 
 glider_devices:

--- a/mission_yaml/SEA45_M52.yml
+++ b/mission_yaml/SEA45_M52.yml
@@ -24,7 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
-sea_name: Baltic
+  sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Kvanne
   glider_serial: "45"

--- a/mission_yaml/SEA45_M52.yml
+++ b/mission_yaml/SEA45_M52.yml
@@ -24,6 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
+sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Kvanne
   glider_serial: "45"
@@ -42,8 +43,6 @@ metadata:
   project: SAMBA
   project_url: https://voiceoftheocean.org/samba-smart-autonomous-monitoring-of-the-baltic-sea/
   summary: ' Part of SAMBA continuous monitoring'
-  # Examples: Skagerrak, Kattegatt, Baltic, Gulf of Bothnia, Gulf of Finland, Gulf of Riga
-  sea_name: Skagerrak
 
 
 glider_devices:

--- a/mission_yaml/SEA45_M54.yml
+++ b/mission_yaml/SEA45_M54.yml
@@ -24,7 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
-sea_name: Baltic
+  sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Kvanne
   glider_serial: "45"

--- a/mission_yaml/SEA45_M54.yml
+++ b/mission_yaml/SEA45_M54.yml
@@ -24,6 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
+sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Kvanne
   glider_serial: "45"
@@ -42,8 +43,6 @@ metadata:
   project: SAMBA
   project_url: https://voiceoftheocean.org/samba-smart-autonomous-monitoring-of-the-baltic-sea/
   summary: ' Part of SAMBA continuous monitoring'
-  # Examples: Skagerrak, Kattegatt, Baltic, Gulf of Bothnia, Gulf of Finland, Gulf of Riga
-  sea_name: Baltic
 
 
 glider_devices:

--- a/mission_yaml/SEA45_M56.yml
+++ b/mission_yaml/SEA45_M56.yml
@@ -24,7 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
-sea_name: Baltic
+  sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Kvanne
   glider_serial: "45"

--- a/mission_yaml/SEA45_M56.yml
+++ b/mission_yaml/SEA45_M56.yml
@@ -24,6 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
+sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Kvanne
   glider_serial: "45"
@@ -42,8 +43,6 @@ metadata:
   project: SAMBA
   project_url: https://voiceoftheocean.org/samba-smart-autonomous-monitoring-of-the-baltic-sea/
   summary: ' Part of SAMBA continuous monitoring'
-  # Examples: Skagerrak, Kattegatt, Baltic, Gulf of Bothnia, Gulf of Finland, Gulf of Riga
-  sea_name: Baltic
 
 
 glider_devices:

--- a/mission_yaml/SEA45_M60.yml
+++ b/mission_yaml/SEA45_M60.yml
@@ -24,7 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
-sea_name: Baltic
+  sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Kvanne
   glider_serial: "45"

--- a/mission_yaml/SEA45_M60.yml
+++ b/mission_yaml/SEA45_M60.yml
@@ -24,6 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
+sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Kvanne
   glider_serial: "45"
@@ -42,8 +43,6 @@ metadata:
   project: SAMBA
   project_url: https://voiceoftheocean.org/samba-smart-autonomous-monitoring-of-the-baltic-sea/
   summary: ' Part of SAMBA continuous monitoring'
-  # Examples: Skagerrak, Kattegatt, Baltic, Gulf of Bothnia, Gulf of Finland, Gulf of Riga
-  sea_name: Baltic
 
 
 glider_devices:

--- a/mission_yaml/SEA55_M16.yml
+++ b/mission_yaml/SEA55_M16.yml
@@ -24,7 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
-sea_name: Baltic
+  sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Kaprifol
   glider_serial: "55"

--- a/mission_yaml/SEA55_M16.yml
+++ b/mission_yaml/SEA55_M16.yml
@@ -24,6 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
+sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Kaprifol
   glider_serial: "55"
@@ -42,8 +43,6 @@ metadata:
   project: SAMBA
   project_url: https://voiceoftheocean.org/samba-smart-autonomous-monitoring-of-the-baltic-sea/
   summary: ' Part of SAMBA continuous monitoring'
-  # Examples: Skagerrak, Kattegatt, Baltic, Gulf of Bothnia, Gulf of Finland, Gulf of Riga
-  sea_name: Baltic
 
 glider_devices:
   altimeter:

--- a/mission_yaml/SEA55_M18.yml
+++ b/mission_yaml/SEA55_M18.yml
@@ -24,7 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
-sea_name: Baltic
+  sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Kaprifol
   glider_serial: "55"

--- a/mission_yaml/SEA55_M18.yml
+++ b/mission_yaml/SEA55_M18.yml
@@ -24,6 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
+sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Kaprifol
   glider_serial: "55"
@@ -42,8 +43,6 @@ metadata:
   project: SAMBA
   project_url: https://voiceoftheocean.org/samba-smart-autonomous-monitoring-of-the-baltic-sea/
   summary: ' Part of SAMBA continuous monitoring'
-  # Examples: Skagerrak, Kattegatt, Baltic, Gulf of Bothnia, Gulf of Finland, Gulf of Riga
-  sea_name: Baltic
 
 glider_devices:
   altimeter:

--- a/mission_yaml/SEA55_M19.yml
+++ b/mission_yaml/SEA55_M19.yml
@@ -24,7 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
-sea_name: Baltic
+  sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Kaprifol
   glider_serial: "55"

--- a/mission_yaml/SEA55_M19.yml
+++ b/mission_yaml/SEA55_M19.yml
@@ -24,6 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
+sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Kaprifol
   glider_serial: "55"
@@ -42,8 +43,6 @@ metadata:
   project: SAMBA
   project_url: https://voiceoftheocean.org/samba-smart-autonomous-monitoring-of-the-baltic-sea/
   summary: ' Part of SAMBA continuous monitoring'
-  # Examples: Skagerrak, Kattegatt, Baltic, Gulf of Bothnia, Gulf of Finland, Gulf of Riga
-  sea_name: Baltic
 
 glider_devices:
   altimeter:

--- a/mission_yaml/SEA55_M20.yml
+++ b/mission_yaml/SEA55_M20.yml
@@ -24,7 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
-sea_name: Baltic
+  sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Kaprifol
   glider_serial: "55"

--- a/mission_yaml/SEA55_M20.yml
+++ b/mission_yaml/SEA55_M20.yml
@@ -24,6 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
+sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Kaprifol
   glider_serial: "55"
@@ -42,8 +43,6 @@ metadata:
   project: SAMBA
   project_url: https://voiceoftheocean.org/samba-smart-autonomous-monitoring-of-the-baltic-sea/
   summary: ' Part of SAMBA continuous monitoring'
-  # Examples: Skagerrak, Kattegatt, Baltic, Gulf of Bothnia, Gulf of Finland, Gulf of Riga
-  sea_name: Baltic
 
 glider_devices:
   altimeter:

--- a/mission_yaml/SEA55_M21.yml
+++ b/mission_yaml/SEA55_M21.yml
@@ -24,7 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
-sea_name: Baltic
+  sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Kaprifol
   glider_serial: "55"

--- a/mission_yaml/SEA55_M21.yml
+++ b/mission_yaml/SEA55_M21.yml
@@ -24,6 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
+sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Kaprifol
   glider_serial: "55"
@@ -42,8 +43,6 @@ metadata:
   project: SAMBA
   project_url: https://voiceoftheocean.org/samba-smart-autonomous-monitoring-of-the-baltic-sea/
   summary: ' Part of SAMBA continuous monitoring'
-  # Examples: Skagerrak, Kattegatt, Baltic, Gulf of Bothnia, Gulf of Finland, Gulf of Riga
-  sea_name: Baltic
 
 glider_devices:
   altimeter:

--- a/mission_yaml/SEA55_M23.yml
+++ b/mission_yaml/SEA55_M23.yml
@@ -24,7 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
-sea_name: Baltic
+  sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Kaprifol
   glider_serial: "55"

--- a/mission_yaml/SEA55_M23.yml
+++ b/mission_yaml/SEA55_M23.yml
@@ -24,6 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
+sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Kaprifol
   glider_serial: "55"
@@ -42,8 +43,6 @@ metadata:
   project: AUV project
   project_url: https://voiceoftheocean.org/samba-smart-autonomous-monitoring-of-the-baltic-sea/
   summary: ' Part of AUV project'
-  # Examples: Skagerrak, Kattegatt, Baltic, Gulf of Bothnia, Gulf of Finland, Gulf of Riga
-  sea_name: Baltic
 
 glider_devices:
   altimeter:

--- a/mission_yaml/SEA55_M24.yml
+++ b/mission_yaml/SEA55_M24.yml
@@ -24,7 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
-sea_name: Baltic
+  sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Kaprifol
   glider_serial: "55"

--- a/mission_yaml/SEA55_M24.yml
+++ b/mission_yaml/SEA55_M24.yml
@@ -24,6 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
+sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Kaprifol
   glider_serial: "55"
@@ -42,8 +43,6 @@ metadata:
   project: SAMBA
   project_url: https://voiceoftheocean.org/samba-smart-autonomous-monitoring-of-the-baltic-sea/
   summary: ' Part of SAMBA continuous monitoring'
-  # Examples: Skagerrak, Kattegatt, Baltic, Gulf of Bothnia, Gulf of Finland, Gulf of Riga
-  sea_name: Baltic
 
 glider_devices:
   altimeter:

--- a/mission_yaml/SEA55_M26.yml
+++ b/mission_yaml/SEA55_M26.yml
@@ -24,6 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
+sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Kaprifol
   glider_serial: "55"
@@ -42,8 +43,6 @@ metadata:
   project: SAMBA
   project_url: https://voiceoftheocean.org/samba-smart-autonomous-monitoring-of-the-baltic-sea/
   summary: ' Part of SAMBA continuous monitoring'
-  # Examples: Skagerrak, Kattegatt, Baltic, Gulf of Bothnia, Gulf of Finland, Gulf of Riga
-  sea_name: Skagerrak
 
 glider_devices:
   altimeter:

--- a/mission_yaml/SEA55_M26.yml
+++ b/mission_yaml/SEA55_M26.yml
@@ -24,7 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
-sea_name: Baltic
+  sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Kaprifol
   glider_serial: "55"

--- a/mission_yaml/SEA55_M28.yml
+++ b/mission_yaml/SEA55_M28.yml
@@ -24,7 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
-sea_name: Baltic
+  sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Kaprifol
   glider_serial: "55"

--- a/mission_yaml/SEA55_M28.yml
+++ b/mission_yaml/SEA55_M28.yml
@@ -24,6 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
+sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Kaprifol
   glider_serial: "55"
@@ -42,8 +43,6 @@ metadata:
   project: SAMBA
   project_url: https://voiceoftheocean.org/samba-smart-autonomous-monitoring-of-the-baltic-sea/
   summary: ' Part of SAMBA continuous monitoring'
-  # Examples: Skagerrak, Kattegatt, Baltic, Gulf of Bothnia, Gulf of Finland, Gulf of Riga
-  sea_name: Baltic
 
 glider_devices:
   altimeter:

--- a/mission_yaml/SEA55_M31.yml
+++ b/mission_yaml/SEA55_M31.yml
@@ -24,7 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
-sea_name: Baltic
+  sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Kaprifol
   glider_serial: "55"

--- a/mission_yaml/SEA55_M31.yml
+++ b/mission_yaml/SEA55_M31.yml
@@ -24,6 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
+sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Kaprifol
   glider_serial: "55"
@@ -42,8 +43,6 @@ metadata:
   project: SAMBA
   project_url: https://voiceoftheocean.org/samba-smart-autonomous-monitoring-of-the-baltic-sea/
   summary: ' Part of SAMBA continuous monitoring'
-  # Examples: Skagerrak, Kattegatt, Baltic, Gulf of Bothnia, Gulf of Finland, Gulf of Riga
-  sea_name: Baltic
 
 glider_devices:
   altimeter:

--- a/mission_yaml/SEA55_M33.yml
+++ b/mission_yaml/SEA55_M33.yml
@@ -24,6 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
+sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Kaprifol
   glider_serial: "55"
@@ -42,8 +43,6 @@ metadata:
   project: SAMBA
   project_url: https://voiceoftheocean.org/samba-smart-autonomous-monitoring-of-the-baltic-sea/
   summary: ' Part of SAMBA continuous monitoring'
-  # Examples: Skagerrak, Kattegatt, Baltic, Gulf of Bothnia, Gulf of Finland, Gulf of Riga
-  sea_name: Skagerrak
 
 glider_devices:
   altimeter:

--- a/mission_yaml/SEA55_M33.yml
+++ b/mission_yaml/SEA55_M33.yml
@@ -24,7 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
-sea_name: Baltic
+  sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Kaprifol
   glider_serial: "55"

--- a/mission_yaml/SEA55_M35.yml
+++ b/mission_yaml/SEA55_M35.yml
@@ -24,6 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
+sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Kaprifol
   glider_serial: "55"
@@ -42,8 +43,6 @@ metadata:
   project: SAMBA
   project_url: https://voiceoftheocean.org/samba-smart-autonomous-monitoring-of-the-baltic-sea/
   summary: ' Part of SAMBA continuous monitoring'
-  # Examples: Skagerrak, Kattegatt, Baltic, Gulf of Bothnia, Gulf of Finland, Gulf of Riga
-  sea_name: Skagerrak
 
 glider_devices:
   altimeter:

--- a/mission_yaml/SEA55_M35.yml
+++ b/mission_yaml/SEA55_M35.yml
@@ -24,7 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
-sea_name: Baltic
+  sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Kaprifol
   glider_serial: "55"

--- a/mission_yaml/SEA55_M37.yml
+++ b/mission_yaml/SEA55_M37.yml
@@ -24,7 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
-sea_name: Baltic
+  sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Kaprifol
   glider_serial: "55"

--- a/mission_yaml/SEA55_M37.yml
+++ b/mission_yaml/SEA55_M37.yml
@@ -24,6 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
+sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Kaprifol
   glider_serial: "55"
@@ -42,8 +43,6 @@ metadata:
   project: SAMBA
   project_url: https://voiceoftheocean.org/samba-smart-autonomous-monitoring-of-the-baltic-sea/
   summary: ' Part of SAMBA continuous monitoring'
-  # Examples: Skagerrak, Kattegatt, Baltic, Gulf of Bothnia, Gulf of Finland, Gulf of Riga
-  sea_name: Baltic
 
 glider_devices:
   altimeter:

--- a/mission_yaml/SEA56_M40.yml
+++ b/mission_yaml/SEA56_M40.yml
@@ -24,6 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
+sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Trift
   glider_serial: "56"
@@ -42,8 +43,6 @@ metadata:
   project: SAMBA
   project_url: https://voiceoftheocean.org/samba-smart-autonomous-monitoring-of-the-baltic-sea/
   summary: ' Part of SAMBA continuous monitoring'
-  # Examples: Skagerrak, Kattegatt, Baltic, Gulf of Bothnia, Gulf of Finland, Gulf of Riga
-  sea_name: Baltic
 
 
 glider_devices:

--- a/mission_yaml/SEA56_M40.yml
+++ b/mission_yaml/SEA56_M40.yml
@@ -24,7 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
-sea_name: Baltic
+  sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Trift
   glider_serial: "56"

--- a/mission_yaml/SEA56_M42.yml
+++ b/mission_yaml/SEA56_M42.yml
@@ -24,6 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
+sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Trift
   glider_serial: "56"
@@ -42,8 +43,6 @@ metadata:
   project: SAMBA
   project_url: https://voiceoftheocean.org/samba-smart-autonomous-monitoring-of-the-baltic-sea/
   summary: ' Part of SAMBA continuous monitoring'
-  # Examples: Skagerrak, Kattegatt, Baltic, Gulf of Bothnia, Gulf of Finland, Gulf of Riga
-  sea_name: Skagerrak
 
 
 glider_devices:

--- a/mission_yaml/SEA56_M42.yml
+++ b/mission_yaml/SEA56_M42.yml
@@ -24,7 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
-sea_name: Baltic
+  sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Trift
   glider_serial: "56"

--- a/mission_yaml/SEA61_M38.yml
+++ b/mission_yaml/SEA61_M38.yml
@@ -24,7 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
-sea_name: Baltic
+  sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Vass
   glider_serial: "61"

--- a/mission_yaml/SEA61_M38.yml
+++ b/mission_yaml/SEA61_M38.yml
@@ -24,6 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
+sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Vass
   glider_serial: "61"
@@ -42,8 +43,6 @@ metadata:
   project: SAMBA
   project_url: https://voiceoftheocean.org/samba-smart-autonomous-monitoring-of-the-baltic-sea/
   summary: ' Part of SAMBA continuous monitoring'
-  # Examples: Skagerrak, Kattegatt, Baltic, Gulf of Bothnia, Gulf of Finland, Gulf of Riga
-  sea_name: Baltic
 
 glider_devices:
   altimeter:

--- a/mission_yaml/SEA61_M39.yml
+++ b/mission_yaml/SEA61_M39.yml
@@ -24,7 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
-sea_name: Baltic
+  sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Vass
   glider_serial: "61"

--- a/mission_yaml/SEA61_M39.yml
+++ b/mission_yaml/SEA61_M39.yml
@@ -24,6 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
+sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Vass
   glider_serial: "61"
@@ -42,8 +43,6 @@ metadata:
   project: SAMBA
   project_url: https://voiceoftheocean.org/samba-smart-autonomous-monitoring-of-the-baltic-sea/
   summary: ' Part of SAMBA continuous monitoring'
-  # Examples: Skagerrak, Kattegatt, Baltic, Gulf of Bothnia, Gulf of Finland, Gulf of Riga
-  sea_name: Baltic
 
 glider_devices:
   altimeter:

--- a/mission_yaml/SEA61_M40.yml
+++ b/mission_yaml/SEA61_M40.yml
@@ -24,7 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
-sea_name: Baltic
+  sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Vass
   glider_serial: "61"

--- a/mission_yaml/SEA61_M40.yml
+++ b/mission_yaml/SEA61_M40.yml
@@ -24,6 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
+sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Vass
   glider_serial: "61"
@@ -42,8 +43,6 @@ metadata:
   project: SAMBA
   project_url: https://voiceoftheocean.org/samba-smart-autonomous-monitoring-of-the-baltic-sea/
   summary: ' Part of SAMBA continuous monitoring'
-  # Examples: Skagerrak, Kattegatt, Baltic, Gulf of Bothnia, Gulf of Finland, Gulf of Riga
-  sea_name: Baltic
 
 glider_devices:
   altimeter:

--- a/mission_yaml/SEA61_M42.yml
+++ b/mission_yaml/SEA61_M42.yml
@@ -24,7 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
-sea_name: Baltic
+  sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Vass
   glider_serial: "61"

--- a/mission_yaml/SEA61_M42.yml
+++ b/mission_yaml/SEA61_M42.yml
@@ -24,6 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
+sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Vass
   glider_serial: "61"
@@ -42,8 +43,6 @@ metadata:
   project: SAMBA
   project_url: https://voiceoftheocean.org/samba-smart-autonomous-monitoring-of-the-baltic-sea/
   summary: ' Part of SAMBA continuous monitoring'
-  # Examples: Skagerrak, Kattegatt, Baltic, Gulf of Bothnia, Gulf of Finland, Gulf of Riga
-  sea_name: Baltic
 
 glider_devices:
   altimeter:

--- a/mission_yaml/SEA61_M43.yml
+++ b/mission_yaml/SEA61_M43.yml
@@ -24,7 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
-sea_name: Baltic
+  sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Vass
   glider_serial: "61"

--- a/mission_yaml/SEA61_M43.yml
+++ b/mission_yaml/SEA61_M43.yml
@@ -24,6 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
+sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Vass
   glider_serial: "61"
@@ -42,8 +43,6 @@ metadata:
   project: SAMBA
   project_url: https://voiceoftheocean.org/samba-smart-autonomous-monitoring-of-the-baltic-sea/
   summary: ' Part of SAMBA continuous monitoring'
-  # Examples: Skagerrak, Kattegatt, Baltic, Gulf of Bothnia, Gulf of Finland, Gulf of Riga
-  sea_name: Baltic
 
 glider_devices:
   altimeter:

--- a/mission_yaml/SEA61_M45.yml
+++ b/mission_yaml/SEA61_M45.yml
@@ -24,6 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
+sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Vass
   glider_serial: "61"
@@ -42,8 +43,6 @@ metadata:
   project: SAMBA
   project_url: https://voiceoftheocean.org/samba-smart-autonomous-monitoring-of-the-baltic-sea/
   summary: ' Part of SAMBA continuous monitoring'
-  # Examples: Skagerrak, Kattegatt, Baltic, Gulf of Bothnia, Gulf of Finland, Gulf of Riga
-  sea_name: Skagerrak
 
 glider_devices:
   altimeter:

--- a/mission_yaml/SEA61_M45.yml
+++ b/mission_yaml/SEA61_M45.yml
@@ -24,7 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
-sea_name: Baltic
+  sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Vass
   glider_serial: "61"

--- a/mission_yaml/SEA61_M48.yml
+++ b/mission_yaml/SEA61_M48.yml
@@ -24,7 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
-sea_name: Baltic
+  sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Vass
   glider_serial: "61"

--- a/mission_yaml/SEA61_M48.yml
+++ b/mission_yaml/SEA61_M48.yml
@@ -24,6 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
+sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Vass
   glider_serial: "61"
@@ -42,8 +43,6 @@ metadata:
   project: SAMBA
   project_url: https://voiceoftheocean.org/samba-smart-autonomous-monitoring-of-the-baltic-sea/
   summary: ' Part of SAMBA continuous monitoring'
-  # Examples: Skagerrak, Kattegatt, Baltic, Gulf of Bothnia, Gulf of Finland, Gulf of Riga
-  sea_name: Baltic
 
 glider_devices:
   altimeter:

--- a/mission_yaml/SEA61_M50.yml
+++ b/mission_yaml/SEA61_M50.yml
@@ -24,7 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
-sea_name: Baltic
+  sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Vass
   glider_serial: "61"

--- a/mission_yaml/SEA61_M50.yml
+++ b/mission_yaml/SEA61_M50.yml
@@ -24,6 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
+sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Vass
   glider_serial: "61"
@@ -42,8 +43,6 @@ metadata:
   project: SAMBA
   project_url: https://voiceoftheocean.org/samba-smart-autonomous-monitoring-of-the-baltic-sea/
   summary: ' Part of SAMBA continuous monitoring'
-  # Examples: Skagerrak, Kattegatt, Baltic, Gulf of Bothnia, Gulf of Finland, Gulf of Riga
-  sea_name: Baltic
 
 glider_devices:
   altimeter:

--- a/mission_yaml/SEA61_M54.yml
+++ b/mission_yaml/SEA61_M54.yml
@@ -24,7 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
-sea_name: Baltic
+  sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Vass
   glider_serial: "61"

--- a/mission_yaml/SEA61_M54.yml
+++ b/mission_yaml/SEA61_M54.yml
@@ -24,6 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
+sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Vass
   glider_serial: "61"
@@ -42,8 +43,6 @@ metadata:
   project: SAMBA
   project_url: https://voiceoftheocean.org/samba-smart-autonomous-monitoring-of-the-baltic-sea/
   summary: ' Part of SAMBA continuous monitoring'
-  # Examples: Skagerrak, Kattegatt, Baltic, Gulf of Bothnia, Gulf of Finland, Gulf of Riga
-  sea_name: Baltic
 
 glider_devices:
   altimeter:

--- a/mission_yaml/SEA61_M56.yml
+++ b/mission_yaml/SEA61_M56.yml
@@ -24,6 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
+sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Vass
   glider_serial: "61"
@@ -42,8 +43,6 @@ metadata:
   project: SAMBA
   project_url: https://voiceoftheocean.org/samba-smart-autonomous-monitoring-of-the-baltic-sea/
   summary: ' Part of SAMBA continuous monitoring'
-  # Examples: Skagerrak, Kattegatt, Baltic, Gulf of Bothnia, Gulf of Finland, Gulf of Riga
-  sea_name: Kattegat, Skagerrak
 
 glider_devices:
   altimeter:

--- a/mission_yaml/SEA61_M56.yml
+++ b/mission_yaml/SEA61_M56.yml
@@ -24,7 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
-sea_name: Baltic
+  sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Vass
   glider_serial: "61"

--- a/mission_yaml/SEA61_M57.yml
+++ b/mission_yaml/SEA61_M57.yml
@@ -24,6 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
+sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Vass
   glider_serial: "61"
@@ -42,8 +43,6 @@ metadata:
   project: SAMBA
   project_url: https://voiceoftheocean.org/samba-smart-autonomous-monitoring-of-the-baltic-sea/
   summary: ' Part of SAMBA continuous monitoring'
-  # Examples: Skagerrak, Kattegatt, Baltic, Gulf of Bothnia, Gulf of Finland, Gulf of Riga
-  sea_name: Kattegat, Skagerrak
 
 glider_devices:
   altimeter:

--- a/mission_yaml/SEA61_M57.yml
+++ b/mission_yaml/SEA61_M57.yml
@@ -24,7 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
-sea_name: Baltic
+  sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Vass
   glider_serial: "61"

--- a/mission_yaml/SEA63_M17.yml
+++ b/mission_yaml/SEA63_M17.yml
@@ -24,7 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
-sea_name: Baltic
+  sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Ljung
   glider_serial: "63"

--- a/mission_yaml/SEA63_M17.yml
+++ b/mission_yaml/SEA63_M17.yml
@@ -24,6 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
+sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Ljung
   glider_serial: "63"
@@ -42,8 +43,6 @@ metadata:
   project: SAMBA
   project_url: https://voiceoftheocean.org/samba-smart-autonomous-monitoring-of-the-baltic-sea/
   summary: ' Part of SAMBA continuous monitoring'
-  # Examples: Skagerrak, Kattegatt, Baltic, Gulf of Bothnia, Gulf of Finland, Gulf of Riga
-  sea_name: Baltic
 
 
 glider_devices:

--- a/mission_yaml/SEA63_M18.yml
+++ b/mission_yaml/SEA63_M18.yml
@@ -24,7 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
-sea_name: Baltic
+  sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Ljung
   glider_serial: "63"

--- a/mission_yaml/SEA63_M18.yml
+++ b/mission_yaml/SEA63_M18.yml
@@ -24,6 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
+sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Ljung
   glider_serial: "63"
@@ -42,8 +43,6 @@ metadata:
   project: SAMBA
   project_url: https://voiceoftheocean.org/samba-smart-autonomous-monitoring-of-the-baltic-sea/
   summary: ' Part of SAMBA continuous monitoring'
-  # Examples: Skagerrak, Kattegatt, Baltic, Gulf of Bothnia, Gulf of Finland, Gulf of Riga
-  sea_name: Baltic
 
 
 glider_devices:

--- a/mission_yaml/SEA63_M19.yml
+++ b/mission_yaml/SEA63_M19.yml
@@ -24,7 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
-sea_name: Baltic
+  sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Ljung
   glider_serial: "63"

--- a/mission_yaml/SEA63_M19.yml
+++ b/mission_yaml/SEA63_M19.yml
@@ -24,6 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
+sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Ljung
   glider_serial: "63"
@@ -42,8 +43,6 @@ metadata:
   project: SAMBA
   project_url: https://voiceoftheocean.org/samba-smart-autonomous-monitoring-of-the-baltic-sea/
   summary: ' Part of SAMBA continuous monitoring'
-  # Examples: Skagerrak, Kattegatt, Baltic, Gulf of Bothnia, Gulf of Finland, Gulf of Riga
-  sea_name: Baltic
 
 
 glider_devices:

--- a/mission_yaml/SEA63_M20.yml
+++ b/mission_yaml/SEA63_M20.yml
@@ -24,7 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
-sea_name: Baltic
+  sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Ljung
   glider_serial: "63"

--- a/mission_yaml/SEA63_M20.yml
+++ b/mission_yaml/SEA63_M20.yml
@@ -24,6 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
+sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Ljung
   glider_serial: "63"
@@ -42,8 +43,6 @@ metadata:
   project: SAMBA
   project_url: https://voiceoftheocean.org/samba-smart-autonomous-monitoring-of-the-baltic-sea/
   summary: ' Part of SAMBA continuous monitoring'
-  # Examples: Skagerrak, Kattegatt, Baltic, Gulf of Bothnia, Gulf of Finland, Gulf of Riga
-  sea_name: Baltic
 
 
 glider_devices:

--- a/mission_yaml/SEA63_M21.yml
+++ b/mission_yaml/SEA63_M21.yml
@@ -24,7 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
-sea_name: Baltic
+  sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Ljung
   glider_serial: "63"

--- a/mission_yaml/SEA63_M21.yml
+++ b/mission_yaml/SEA63_M21.yml
@@ -24,6 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
+sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Ljung
   glider_serial: "63"
@@ -42,8 +43,6 @@ metadata:
   project: SAMBA
   project_url: https://voiceoftheocean.org/samba-smart-autonomous-monitoring-of-the-baltic-sea/
   summary: ' Part of SAMBA continuous monitoring'
-  # Examples: Skagerrak, Kattegatt, Baltic, Gulf of Bothnia, Gulf of Finland, Gulf of Riga
-  sea_name: Baltic
 
 
 glider_devices:

--- a/mission_yaml/SEA63_M22.yml
+++ b/mission_yaml/SEA63_M22.yml
@@ -24,7 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
-sea_name: Baltic
+  sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Ljung
   glider_serial: "63"

--- a/mission_yaml/SEA63_M22.yml
+++ b/mission_yaml/SEA63_M22.yml
@@ -24,6 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
+sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Ljung
   glider_serial: "63"
@@ -42,8 +43,6 @@ metadata:
   project: SAMBA
   project_url: https://voiceoftheocean.org/samba-smart-autonomous-monitoring-of-the-baltic-sea/
   summary: ' Part of SAMBA continuous monitoring'
-  # Examples: Skagerrak, Kattegatt, Baltic, Gulf of Bothnia, Gulf of Finland, Gulf of Riga
-  sea_name: Baltic
 
 
 glider_devices:

--- a/mission_yaml/SEA63_M24.yml
+++ b/mission_yaml/SEA63_M24.yml
@@ -24,7 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
-sea_name: Baltic
+  sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Ljung
   glider_serial: "63"

--- a/mission_yaml/SEA63_M24.yml
+++ b/mission_yaml/SEA63_M24.yml
@@ -24,6 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
+sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Ljung
   glider_serial: "63"
@@ -42,8 +43,6 @@ metadata:
   project: SAMBA
   project_url: https://voiceoftheocean.org/samba-smart-autonomous-monitoring-of-the-baltic-sea/
   summary: ' Part of SAMBA continuous monitoring'
-  # Examples: Skagerrak, Kattegatt, Baltic, Gulf of Bothnia, Gulf of Finland, Gulf of Riga
-  sea_name: Skagerrak
 
 
 glider_devices:

--- a/mission_yaml/SEA63_M33.yml
+++ b/mission_yaml/SEA63_M33.yml
@@ -24,7 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
-sea_name: Baltic
+  sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Ljung
   glider_serial: "63"

--- a/mission_yaml/SEA63_M33.yml
+++ b/mission_yaml/SEA63_M33.yml
@@ -24,6 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
+sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Ljung
   glider_serial: "63"
@@ -42,8 +43,6 @@ metadata:
   project: SAMBA
   project_url: https://voiceoftheocean.org/samba-smart-autonomous-monitoring-of-the-baltic-sea/
   summary: ' Part of SAMBA continuous monitoring'
-  # Examples: Skagerrak, Kattegatt, Baltic, Gulf of Bothnia, Gulf of Finland, Gulf of Riga
-  sea_name: Baltic
 
 
 glider_devices:

--- a/mission_yaml/SEA63_M35.yml
+++ b/mission_yaml/SEA63_M35.yml
@@ -24,7 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
-sea_name: Baltic
+  sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Ljung
   glider_serial: "63"

--- a/mission_yaml/SEA63_M35.yml
+++ b/mission_yaml/SEA63_M35.yml
@@ -24,6 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
+sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Ljung
   glider_serial: "63"
@@ -42,8 +43,6 @@ metadata:
   project: SAMBA
   project_url: https://voiceoftheocean.org/samba-smart-autonomous-monitoring-of-the-baltic-sea/
   summary: ' Part of SAMBA continuous monitoring'
-  # Examples: Skagerrak, Kattegatt, Baltic, Gulf of Bothnia, Gulf of Finland, Gulf of Riga
-  sea_name: Baltic
 
 
 glider_devices:

--- a/mission_yaml/SEA63_M37.yml
+++ b/mission_yaml/SEA63_M37.yml
@@ -24,7 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
-sea_name: Baltic
+  sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Ljung
   glider_serial: "63"

--- a/mission_yaml/SEA63_M37.yml
+++ b/mission_yaml/SEA63_M37.yml
@@ -24,6 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
+sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Ljung
   glider_serial: "63"
@@ -42,8 +43,6 @@ metadata:
   project: SAMBA
   project_url: https://voiceoftheocean.org/samba-smart-autonomous-monitoring-of-the-baltic-sea/
   summary: ' Part of SAMBA continuous monitoring'
-  # Examples: Skagerrak, Kattegatt, Baltic, Gulf of Bothnia, Gulf of Finland, Gulf of Riga
-  sea_name: Baltic
 
 
 glider_devices:

--- a/mission_yaml/SEA66_M10.yml
+++ b/mission_yaml/SEA66_M10.yml
@@ -24,6 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
+sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Saltarv
   glider_serial: "66"
@@ -42,8 +43,6 @@ metadata:
   project: SAMBA
   project_url: https://voiceoftheocean.org/samba-smart-autonomous-monitoring-of-the-baltic-sea/
   summary: ' Part of SAMBA continuous monitoring'
-  # Examples: Skagerrak, Kattegatt, Baltic, Gulf of Bothnia, Gulf of Finland, Gulf of Riga
-  sea_name: Baltic
 
 
 glider_devices:

--- a/mission_yaml/SEA66_M10.yml
+++ b/mission_yaml/SEA66_M10.yml
@@ -24,7 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
-sea_name: Baltic
+  sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Saltarv
   glider_serial: "66"

--- a/mission_yaml/SEA66_M12.yml
+++ b/mission_yaml/SEA66_M12.yml
@@ -24,6 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
+sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Saltarv
   glider_serial: "66"
@@ -42,8 +43,6 @@ metadata:
   project: SAMBA
   project_url: https://voiceoftheocean.org/samba-smart-autonomous-monitoring-of-the-baltic-sea/
   summary: ' Part of SAMBA continuous monitoring'
-  # Examples: Skagerrak, Kattegatt, Baltic, Gulf of Bothnia, Gulf of Finland, Gulf of Riga
-  sea_name: Baltic
 
 
 glider_devices:

--- a/mission_yaml/SEA66_M12.yml
+++ b/mission_yaml/SEA66_M12.yml
@@ -24,7 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
-sea_name: Baltic
+  sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Saltarv
   glider_serial: "66"

--- a/mission_yaml/SEA66_M14.yml
+++ b/mission_yaml/SEA66_M14.yml
@@ -24,6 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
+sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Saltarv
   glider_serial: "66"
@@ -42,8 +43,6 @@ metadata:
   project: SAMBA
   project_url: https://voiceoftheocean.org/samba-smart-autonomous-monitoring-of-the-baltic-sea/
   summary: ' Part of SAMBA continuous monitoring'
-  # Examples: Skagerrak, Kattegatt, Baltic, Gulf of Bothnia, Gulf of Finland, Gulf of Riga
-  sea_name: Baltic
 
 
 glider_devices:

--- a/mission_yaml/SEA66_M14.yml
+++ b/mission_yaml/SEA66_M14.yml
@@ -24,7 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
-sea_name: Baltic
+  sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Saltarv
   glider_serial: "66"

--- a/mission_yaml/SEA66_M16.yml
+++ b/mission_yaml/SEA66_M16.yml
@@ -24,7 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
-sea_name: Baltic
+  sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Saltarv
   glider_serial: "66"

--- a/mission_yaml/SEA66_M16.yml
+++ b/mission_yaml/SEA66_M16.yml
@@ -24,6 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
+sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Saltarv
   glider_serial: "66"
@@ -42,8 +43,6 @@ metadata:
   project: SAMBA
   project_url: https://voiceoftheocean.org/samba-smart-autonomous-monitoring-of-the-baltic-sea/
   summary: ' Part of SAMBA continuous monitoring'
-  # Examples: Skagerrak, Kattegatt, Baltic, Gulf of Bothnia, Gulf of Finland, Gulf of Riga
-  sea_name: Skagerrak
 
 
 glider_devices:

--- a/mission_yaml/SEA67_M15.yml
+++ b/mission_yaml/SEA67_M15.yml
@@ -24,6 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
+sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Marviol
   glider_serial: "67"
@@ -42,8 +43,6 @@ metadata:
   project: SAMBA
   project_url: https://voiceoftheocean.org/samba-smart-autonomous-monitoring-of-the-baltic-sea/
   summary: ' Part of SAMBA continuous monitoring'
-  # Examples: Skagerrak, Kattegatt, Baltic, Gulf of Bothnia, Gulf of Finland, Gulf of Riga
-  sea_name: Baltic
 
 
 glider_devices:

--- a/mission_yaml/SEA67_M15.yml
+++ b/mission_yaml/SEA67_M15.yml
@@ -24,7 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
-sea_name: Baltic
+  sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Marviol
   glider_serial: "67"

--- a/mission_yaml/SEA67_M26.yml
+++ b/mission_yaml/SEA67_M26.yml
@@ -24,7 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
-sea_name: Baltic
+  sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Marviol
   glider_serial: "67"

--- a/mission_yaml/SEA67_M26.yml
+++ b/mission_yaml/SEA67_M26.yml
@@ -24,6 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
+sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Marviol
   glider_serial: "67"
@@ -42,8 +43,6 @@ metadata:
   project: CABLE
   project_url: https://voiceoftheocean.org/knowledge/
   summary: 'Part of CABLE project'
-  # Examples: Skagerrak, Kattegatt, Baltic, Gulf of Bothnia, Gulf of Finland, Gulf of Riga
-  sea_name: Baltic
 
 
 glider_devices:

--- a/mission_yaml/SEA67_M27.yml
+++ b/mission_yaml/SEA67_M27.yml
@@ -24,7 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
-sea_name: Baltic
+  sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Marviol
   glider_serial: "67"

--- a/mission_yaml/SEA67_M27.yml
+++ b/mission_yaml/SEA67_M27.yml
@@ -24,6 +24,7 @@ metadata:
   references:     "created with pyglider https://github.com/c-proof/pyglider"
   source:     Observational data from a profiling glider.
   standard_name_vocabulary: CF STandard Name Table v49
+sea_name: Baltic
   transmission_system: IRIDIUM
   glider_name: Marviol
   glider_serial: "67"
@@ -42,8 +43,6 @@ metadata:
   project: CABLE
   project_url: https://voiceoftheocean.org/knowledge/
   summary: 'Part of CABLE project'
-  # Examples: Skagerrak, Kattegatt, Baltic, Gulf of Bothnia, Gulf of Finland, Gulf of Riga
-  sea_name: Baltic
 
 
 glider_devices:

--- a/yaml_checker.py
+++ b/yaml_checker.py
@@ -111,7 +111,7 @@ def check_against_meta(deployment_meta, _log):
                      'glider_instrument_name', 'keywords', 'keywords_vocabulary', 'metadata_link',
                      'Metadata_Conventions', 'naming_authority', 'platform', 'processing_level', 'publisher_email',
                      'publisher_name', 'publisher_url', 'references', 'source', 'standard_name_vocabulary',
-                     'transmission_system')
+                     'transmission_system', 'sea_name')
     for key in constant_vals:
         if deployment_meta[key] != meta[key]:
             _log.error(f'{key}: {deployment_meta[key]} does not match value {meta[key]} in meta.yaml')


### PR DESCRIPTION
This PR changes sea_name in all yml files to Baltic. Sub-regions within the Baltic will be added to the datafiles using the lon, lat from the glider and the Helcom regions as defined in [the helcom monitoring streategy](https://helcom.fi/media/publications/Monitoring-and-assessment-strategy.pdf).

To achieve this, I used sed:

sed -i /sea_name/d SEA*.yml
sed -i /Examples/d SEA*.yml
sed -i '/standard_name_vocabulary/a \ \ sea_name: Baltic' SEA*.yml