### PR TITLE
Geometric mean

### DIFF
--- a/mission_yaml/SEA44_M25.yml
+++ b/mission_yaml/SEA44_M25.yml
@@ -312,6 +312,7 @@ netcdf_variables:
     long_name:    Downwelling irradiance value of the 380 nm wavelength
     standard_name: 380nm_downwelling_irradiance
     units:        W m-2 nm-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"
@@ -321,6 +322,7 @@ netcdf_variables:
     long_name:    Downwelling irradiance value of the 490 nm wavelength
     standard_name: 490nm_downwelling_irradiance
     units:        W m-2 nm-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"
@@ -330,6 +332,7 @@ netcdf_variables:
     long_name:    Downwelling irradiance value of the 532 nm wavelength
     standard_name: 532nm_downwelling_irradiance
     units:       W m-2 nm-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"
@@ -339,6 +342,7 @@ netcdf_variables:
     long_name:    Downwelling PAR (Photosynthetically Active Radiation) in range 400-700 nm
     standard_name: downwelling_PAR
     units:        μE m-2 s-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"

--- a/mission_yaml/SEA44_M28.yml
+++ b/mission_yaml/SEA44_M28.yml
@@ -312,6 +312,7 @@ netcdf_variables:
     long_name:    Downwelling irradiance value of the 380 nm wavelength
     standard_name: 380nm_downwelling_irradiance
     units:        W m-2 nm-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"
@@ -321,6 +322,7 @@ netcdf_variables:
     long_name:    Downwelling irradiance value of the 490 nm wavelength
     standard_name: 490nm_downwelling_irradiance
     units:        W m-2 nm-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"
@@ -330,6 +332,7 @@ netcdf_variables:
     long_name:    Downwelling irradiance value of the 532 nm wavelength
     standard_name: 532nm_downwelling_irradiance
     units:       W m-2 nm-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"
@@ -339,6 +342,7 @@ netcdf_variables:
     long_name:    Downwelling PAR (Photosynthetically Active Radiation) in range 400-700 nm
     standard_name: downwelling_PAR
     units:        μE m-2 s-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"

--- a/mission_yaml/SEA44_M29.yml
+++ b/mission_yaml/SEA44_M29.yml
@@ -312,6 +312,7 @@ netcdf_variables:
     long_name:    Downwelling irradiance value of the 380 nm wavelength
     standard_name: 380nm_downwelling_irradiance
     units:        W m-2 nm-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"
@@ -321,6 +322,7 @@ netcdf_variables:
     long_name:    Downwelling irradiance value of the 490 nm wavelength
     standard_name: 490nm_downwelling_irradiance
     units:        W m-2 nm-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"
@@ -330,6 +332,7 @@ netcdf_variables:
     long_name:    Downwelling irradiance value of the 532 nm wavelength
     standard_name: 532nm_downwelling_irradiance
     units:       W m-2 nm-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"
@@ -339,6 +342,7 @@ netcdf_variables:
     long_name:    Downwelling PAR (Photosynthetically Active Radiation) in range 400-700 nm
     standard_name: downwelling_PAR
     units:        μE m-2 s-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"

--- a/mission_yaml/SEA44_M32.yml
+++ b/mission_yaml/SEA44_M32.yml
@@ -312,6 +312,7 @@ netcdf_variables:
     long_name:    Downwelling irradiance value of the 380 nm wavelength
     standard_name: 380nm_downwelling_irradiance
     units:        W m-2 nm-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"
@@ -321,6 +322,7 @@ netcdf_variables:
     long_name:    Downwelling irradiance value of the 490 nm wavelength
     standard_name: 490nm_downwelling_irradiance
     units:        W m-2 nm-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"
@@ -330,6 +332,7 @@ netcdf_variables:
     long_name:    Downwelling irradiance value of the 532 nm wavelength
     standard_name: 532nm_downwelling_irradiance
     units:       W m-2 nm-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"
@@ -339,6 +342,7 @@ netcdf_variables:
     long_name:    Downwelling PAR (Photosynthetically Active Radiation) in range 400-700 nm
     standard_name: downwelling_PAR
     units:        μE m-2 s-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"

--- a/mission_yaml/SEA44_M33.yml
+++ b/mission_yaml/SEA44_M33.yml
@@ -312,6 +312,7 @@ netcdf_variables:
     long_name:    Downwelling irradiance value of the 380 nm wavelength
     standard_name: 380nm_downwelling_irradiance
     units:        W m-2 nm-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"
@@ -321,6 +322,7 @@ netcdf_variables:
     long_name:    Downwelling irradiance value of the 490 nm wavelength
     standard_name: 490nm_downwelling_irradiance
     units:        W m-2 nm-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"
@@ -330,6 +332,7 @@ netcdf_variables:
     long_name:    Downwelling irradiance value of the 532 nm wavelength
     standard_name: 532nm_downwelling_irradiance
     units:       W m-2 nm-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"
@@ -339,6 +342,7 @@ netcdf_variables:
     long_name:    Downwelling PAR (Photosynthetically Active Radiation) in range 400-700 nm
     standard_name: downwelling_PAR
     units:        μE m-2 s-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"

--- a/mission_yaml/SEA44_M34.yml
+++ b/mission_yaml/SEA44_M34.yml
@@ -312,6 +312,7 @@ netcdf_variables:
     long_name:    Downwelling irradiance value of the 380 nm wavelength
     standard_name: 380nm_downwelling_irradiance
     units:        W m-2 nm-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"
@@ -321,6 +322,7 @@ netcdf_variables:
     long_name:    Downwelling irradiance value of the 490 nm wavelength
     standard_name: 490nm_downwelling_irradiance
     units:        W m-2 nm-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"
@@ -330,6 +332,7 @@ netcdf_variables:
     long_name:    Downwelling irradiance value of the 532 nm wavelength
     standard_name: 532nm_downwelling_irradiance
     units:       W m-2 nm-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"
@@ -339,6 +342,7 @@ netcdf_variables:
     long_name:    Downwelling PAR (Photosynthetically Active Radiation) in range 400-700 nm
     standard_name: downwelling_PAR
     units:        μE m-2 s-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"

--- a/mission_yaml/SEA44_M35.yml
+++ b/mission_yaml/SEA44_M35.yml
@@ -312,6 +312,7 @@ netcdf_variables:
     long_name:    Downwelling irradiance value of the 380 nm wavelength
     standard_name: 380nm_downwelling_irradiance
     units:        W m-2 nm-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"
@@ -321,6 +322,7 @@ netcdf_variables:
     long_name:    Downwelling irradiance value of the 490 nm wavelength
     standard_name: 490nm_downwelling_irradiance
     units:        W m-2 nm-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"
@@ -330,6 +332,7 @@ netcdf_variables:
     long_name:    Downwelling irradiance value of the 532 nm wavelength
     standard_name: 532nm_downwelling_irradiance
     units:       W m-2 nm-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"
@@ -339,6 +342,7 @@ netcdf_variables:
     long_name:    Downwelling PAR (Photosynthetically Active Radiation) in range 400-700 nm
     standard_name: downwelling_PAR
     units:        μE m-2 s-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"

--- a/mission_yaml/SEA44_M40.yml
+++ b/mission_yaml/SEA44_M40.yml
@@ -312,6 +312,7 @@ netcdf_variables:
     long_name:    Downwelling irradiance value of the 380 nm wavelength
     standard_name: 380nm_downwelling_irradiance
     units:        W m-2 nm-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"
@@ -321,6 +322,7 @@ netcdf_variables:
     long_name:    Downwelling irradiance value of the 490 nm wavelength
     standard_name: 490nm_downwelling_irradiance
     units:        W m-2 nm-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"
@@ -330,6 +332,7 @@ netcdf_variables:
     long_name:    Downwelling irradiance value of the 532 nm wavelength
     standard_name: 532nm_downwelling_irradiance
     units:       W m-2 nm-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"
@@ -339,6 +342,7 @@ netcdf_variables:
     long_name:    Downwelling PAR (Photosynthetically Active Radiation) in range 400-700 nm
     standard_name: downwelling_PAR
     units:        μE m-2 s-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"

--- a/mission_yaml/SEA44_M45.yml
+++ b/mission_yaml/SEA44_M45.yml
@@ -312,6 +312,7 @@ netcdf_variables:
     long_name:    Downwelling irradiance value of the 380 nm wavelength
     standard_name: 380nm_downwelling_irradiance
     units:        W m-2 nm-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"
@@ -321,6 +322,7 @@ netcdf_variables:
     long_name:    Downwelling irradiance value of the 490 nm wavelength
     standard_name: 490nm_downwelling_irradiance
     units:        W m-2 nm-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"
@@ -330,6 +332,7 @@ netcdf_variables:
     long_name:    Downwelling irradiance value of the 532 nm wavelength
     standard_name: 532nm_downwelling_irradiance
     units:       W m-2 nm-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"
@@ -339,6 +342,7 @@ netcdf_variables:
     long_name:    Downwelling PAR (Photosynthetically Active Radiation) in range 400-700 nm
     standard_name: downwelling_PAR
     units:        μE m-2 s-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"

--- a/mission_yaml/SEA44_M46.yml
+++ b/mission_yaml/SEA44_M46.yml
@@ -312,6 +312,7 @@ netcdf_variables:
     long_name:    Downwelling irradiance value of the 380 nm wavelength
     standard_name: 380nm_downwelling_irradiance
     units:        W m-2 nm-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"
@@ -321,6 +322,7 @@ netcdf_variables:
     long_name:    Downwelling irradiance value of the 490 nm wavelength
     standard_name: 490nm_downwelling_irradiance
     units:        W m-2 nm-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"
@@ -330,6 +332,7 @@ netcdf_variables:
     long_name:    Downwelling irradiance value of the 532 nm wavelength
     standard_name: 532nm_downwelling_irradiance
     units:       W m-2 nm-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"
@@ -339,6 +342,7 @@ netcdf_variables:
     long_name:    Downwelling PAR (Photosynthetically Active Radiation) in range 400-700 nm
     standard_name: downwelling_PAR
     units:        μE m-2 s-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"

--- a/mission_yaml/SEA44_M48.yml
+++ b/mission_yaml/SEA44_M48.yml
@@ -312,6 +312,7 @@ netcdf_variables:
     long_name:    Downwelling irradiance value of the 380 nm wavelength
     standard_name: 380nm_downwelling_irradiance
     units:        W m-2 nm-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"
@@ -321,6 +322,7 @@ netcdf_variables:
     long_name:    Downwelling irradiance value of the 490 nm wavelength
     standard_name: 490nm_downwelling_irradiance
     units:        W m-2 nm-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"
@@ -330,6 +332,7 @@ netcdf_variables:
     long_name:    Downwelling irradiance value of the 532 nm wavelength
     standard_name: 532nm_downwelling_irradiance
     units:       W m-2 nm-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"
@@ -339,6 +342,7 @@ netcdf_variables:
     long_name:    Downwelling PAR (Photosynthetically Active Radiation) in range 400-700 nm
     standard_name: downwelling_PAR
     units:        μE m-2 s-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"

--- a/mission_yaml/SEA55_M16.yml
+++ b/mission_yaml/SEA55_M16.yml
@@ -312,6 +312,7 @@ netcdf_variables:
     long_name:    Downwelling irradiance value of the 380 nm wavelength
     standard_name: 380nm_downwelling_irradiance
     units:        W m-2 nm-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"
@@ -321,6 +322,7 @@ netcdf_variables:
     long_name:    Downwelling irradiance value of the 490 nm wavelength
     standard_name: 490nm_downwelling_irradiance
     units:        W m-2 nm-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"
@@ -330,6 +332,7 @@ netcdf_variables:
     long_name:    Downwelling irradiance value of the 532 nm wavelength
     standard_name: 532nm_downwelling_irradiance
     units:       W m-2 nm-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"
@@ -339,6 +342,7 @@ netcdf_variables:
     long_name:    Downwelling PAR (Photosynthetically Active Radiation) in range 400-700 nm
     standard_name: downwelling_PAR
     units:        μE m-2 s-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"

--- a/mission_yaml/SEA55_M18.yml
+++ b/mission_yaml/SEA55_M18.yml
@@ -312,6 +312,7 @@ netcdf_variables:
     long_name:    Downwelling irradiance value of the 380 nm wavelength
     standard_name: 380nm_downwelling_irradiance
     units:        W m-2 nm-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"
@@ -321,6 +322,7 @@ netcdf_variables:
     long_name:    Downwelling irradiance value of the 490 nm wavelength
     standard_name: 490nm_downwelling_irradiance
     units:        W m-2 nm-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"
@@ -330,6 +332,7 @@ netcdf_variables:
     long_name:    Downwelling irradiance value of the 532 nm wavelength
     standard_name: 532nm_downwelling_irradiance
     units:       W m-2 nm-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"
@@ -339,6 +342,7 @@ netcdf_variables:
     long_name:    Downwelling PAR (Photosynthetically Active Radiation) in range 400-700 nm
     standard_name: downwelling_PAR
     units:        μE m-2 s-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"

--- a/mission_yaml/SEA55_M19.yml
+++ b/mission_yaml/SEA55_M19.yml
@@ -312,6 +312,7 @@ netcdf_variables:
     long_name:    Downwelling irradiance value of the 380 nm wavelength
     standard_name: 380nm_downwelling_irradiance
     units:        W m-2 nm-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"
@@ -321,6 +322,7 @@ netcdf_variables:
     long_name:    Downwelling irradiance value of the 490 nm wavelength
     standard_name: 490nm_downwelling_irradiance
     units:        W m-2 nm-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"
@@ -330,6 +332,7 @@ netcdf_variables:
     long_name:    Downwelling irradiance value of the 532 nm wavelength
     standard_name: 532nm_downwelling_irradiance
     units:       W m-2 nm-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"
@@ -339,6 +342,7 @@ netcdf_variables:
     long_name:    Downwelling PAR (Photosynthetically Active Radiation) in range 400-700 nm
     standard_name: downwelling_PAR
     units:        μE m-2 s-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"

--- a/mission_yaml/SEA55_M20.yml
+++ b/mission_yaml/SEA55_M20.yml
@@ -312,6 +312,7 @@ netcdf_variables:
     long_name:    Downwelling irradiance value of the 380 nm wavelength
     standard_name: 380nm_downwelling_irradiance
     units:        W m-2 nm-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"
@@ -321,6 +322,7 @@ netcdf_variables:
     long_name:    Downwelling irradiance value of the 490 nm wavelength
     standard_name: 490nm_downwelling_irradiance
     units:        W m-2 nm-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"
@@ -330,6 +332,7 @@ netcdf_variables:
     long_name:    Downwelling irradiance value of the 532 nm wavelength
     standard_name: 532nm_downwelling_irradiance
     units:       W m-2 nm-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"
@@ -339,6 +342,7 @@ netcdf_variables:
     long_name:    Downwelling PAR (Photosynthetically Active Radiation) in range 400-700 nm
     standard_name: downwelling_PAR
     units:        μE m-2 s-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"

--- a/mission_yaml/SEA55_M21.yml
+++ b/mission_yaml/SEA55_M21.yml
@@ -312,6 +312,7 @@ netcdf_variables:
     long_name:    Downwelling irradiance value of the 380 nm wavelength
     standard_name: 380nm_downwelling_irradiance
     units:        W m-2 nm-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"
@@ -321,6 +322,7 @@ netcdf_variables:
     long_name:    Downwelling irradiance value of the 490 nm wavelength
     standard_name: 490nm_downwelling_irradiance
     units:        W m-2 nm-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"
@@ -330,6 +332,7 @@ netcdf_variables:
     long_name:    Downwelling irradiance value of the 532 nm wavelength
     standard_name: 532nm_downwelling_irradiance
     units:       W m-2 nm-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"
@@ -339,6 +342,7 @@ netcdf_variables:
     long_name:    Downwelling PAR (Photosynthetically Active Radiation) in range 400-700 nm
     standard_name: downwelling_PAR
     units:        μE m-2 s-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"

--- a/mission_yaml/SEA55_M23.yml
+++ b/mission_yaml/SEA55_M23.yml
@@ -312,6 +312,7 @@ netcdf_variables:
     long_name:    Downwelling irradiance value of the 380 nm wavelength
     standard_name: 380nm_downwelling_irradiance
     units:        W m-2 nm-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"
@@ -321,6 +322,7 @@ netcdf_variables:
     long_name:    Downwelling irradiance value of the 490 nm wavelength
     standard_name: 490nm_downwelling_irradiance
     units:        W m-2 nm-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"
@@ -330,6 +332,7 @@ netcdf_variables:
     long_name:    Downwelling irradiance value of the 532 nm wavelength
     standard_name: 532nm_downwelling_irradiance
     units:       W m-2 nm-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"
@@ -339,6 +342,7 @@ netcdf_variables:
     long_name:    Downwelling PAR (Photosynthetically Active Radiation) in range 400-700 nm
     standard_name: downwelling_PAR
     units:        μE m-2 s-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"

--- a/mission_yaml/SEA55_M24.yml
+++ b/mission_yaml/SEA55_M24.yml
@@ -312,6 +312,7 @@ netcdf_variables:
     long_name:    Downwelling irradiance value of the 380 nm wavelength
     standard_name: 380nm_downwelling_irradiance
     units:        W m-2 nm-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"
@@ -321,6 +322,7 @@ netcdf_variables:
     long_name:    Downwelling irradiance value of the 490 nm wavelength
     standard_name: 490nm_downwelling_irradiance
     units:        W m-2 nm-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"
@@ -330,6 +332,7 @@ netcdf_variables:
     long_name:    Downwelling irradiance value of the 532 nm wavelength
     standard_name: 532nm_downwelling_irradiance
     units:       W m-2 nm-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"
@@ -339,6 +342,7 @@ netcdf_variables:
     long_name:    Downwelling PAR (Photosynthetically Active Radiation) in range 400-700 nm
     standard_name: downwelling_PAR
     units:        μE m-2 s-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"

--- a/mission_yaml/SEA55_M26.yml
+++ b/mission_yaml/SEA55_M26.yml
@@ -312,6 +312,7 @@ netcdf_variables:
     long_name:    Downwelling irradiance value of the 380 nm wavelength
     standard_name: 380nm_downwelling_irradiance
     units:        W m-2 nm-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"
@@ -321,6 +322,7 @@ netcdf_variables:
     long_name:    Downwelling irradiance value of the 490 nm wavelength
     standard_name: 490nm_downwelling_irradiance
     units:        W m-2 nm-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"
@@ -330,6 +332,7 @@ netcdf_variables:
     long_name:    Downwelling irradiance value of the 532 nm wavelength
     standard_name: 532nm_downwelling_irradiance
     units:       W m-2 nm-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"
@@ -339,6 +342,7 @@ netcdf_variables:
     long_name:    Downwelling PAR (Photosynthetically Active Radiation) in range 400-700 nm
     standard_name: downwelling_PAR
     units:        μE m-2 s-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"

--- a/mission_yaml/SEA55_M28.yml
+++ b/mission_yaml/SEA55_M28.yml
@@ -312,6 +312,7 @@ netcdf_variables:
     long_name:    Downwelling irradiance value of the 380 nm wavelength
     standard_name: 380nm_downwelling_irradiance
     units:        W m-2 nm-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"
@@ -321,6 +322,7 @@ netcdf_variables:
     long_name:    Downwelling irradiance value of the 490 nm wavelength
     standard_name: 490nm_downwelling_irradiance
     units:        W m-2 nm-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"
@@ -330,6 +332,7 @@ netcdf_variables:
     long_name:    Downwelling irradiance value of the 532 nm wavelength
     standard_name: 532nm_downwelling_irradiance
     units:       W m-2 nm-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"
@@ -339,6 +342,7 @@ netcdf_variables:
     long_name:    Downwelling PAR (Photosynthetically Active Radiation) in range 400-700 nm
     standard_name: downwelling_PAR
     units:        μE m-2 s-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"

--- a/mission_yaml/SEA55_M31.yml
+++ b/mission_yaml/SEA55_M31.yml
@@ -312,6 +312,7 @@ netcdf_variables:
     long_name:    Downwelling irradiance value of the 380 nm wavelength
     standard_name: 380nm_downwelling_irradiance
     units:        W m-2 nm-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"
@@ -321,6 +322,7 @@ netcdf_variables:
     long_name:    Downwelling irradiance value of the 490 nm wavelength
     standard_name: 490nm_downwelling_irradiance
     units:        W m-2 nm-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"
@@ -330,6 +332,7 @@ netcdf_variables:
     long_name:    Downwelling irradiance value of the 532 nm wavelength
     standard_name: 532nm_downwelling_irradiance
     units:       W m-2 nm-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"
@@ -339,6 +342,7 @@ netcdf_variables:
     long_name:    Downwelling PAR (Photosynthetically Active Radiation) in range 400-700 nm
     standard_name: downwelling_PAR
     units:        μE m-2 s-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"

--- a/mission_yaml/SEA55_M33.yml
+++ b/mission_yaml/SEA55_M33.yml
@@ -312,6 +312,7 @@ netcdf_variables:
 #     long_name:    Downwelling irradiance value of the 380 nm wavelength
 #     standard_name: 380nm_downwelling_irradiance
 #     units:        W m-2 nm-1
+    average_method: "geometric mean"
 #     coordinates:   time depth latitude longitude
 #     instrument:    instrument_radiometer
 #     observation_type: "measured"
@@ -321,6 +322,7 @@ netcdf_variables:
 #     long_name:    Downwelling irradiance value of the 490 nm wavelength
 #     standard_name: 490nm_downwelling_irradiance
 #     units:        W m-2 nm-1
+    average_method: "geometric mean"
 #     coordinates:   time depth latitude longitude
 #     instrument:    instrument_radiometer
 #     observation_type: "measured"
@@ -330,6 +332,7 @@ netcdf_variables:
 #     long_name:    Downwelling irradiance value of the 532 nm wavelength
 #     standard_name: 532nm_downwelling_irradiance
 #     units:       W m-2 nm-1
+    average_method: "geometric mean"
 #     coordinates:   time depth latitude longitude
 #     instrument:    instrument_radiometer
 #     observation_type: "measured"
@@ -339,6 +342,7 @@ netcdf_variables:
 #     long_name:    Downwelling PAR (Photosynthetically Active Radiation) in range 400-700 nm
 #     standard_name: downwelling_PAR
 #     units:        μE m-2 s-1
+    average_method: "geometric mean"
 #     coordinates:   time depth latitude longitude
 #     instrument:    instrument_radiometer
 #     observation_type: "measured"

--- a/mission_yaml/SEA55_M35.yml
+++ b/mission_yaml/SEA55_M35.yml
@@ -312,6 +312,7 @@ netcdf_variables:
 #     long_name:    Downwelling irradiance value of the 380 nm wavelength
 #     standard_name: 380nm_downwelling_irradiance
 #     units:        W m-2 nm-1
+    average_method: "geometric mean"
 #     coordinates:   time depth latitude longitude
 #     instrument:    instrument_radiometer
 #     observation_type: "measured"
@@ -321,6 +322,7 @@ netcdf_variables:
 #     long_name:    Downwelling irradiance value of the 490 nm wavelength
 #     standard_name: 490nm_downwelling_irradiance
 #     units:        W m-2 nm-1
+    average_method: "geometric mean"
 #     coordinates:   time depth latitude longitude
 #     instrument:    instrument_radiometer
 #     observation_type: "measured"
@@ -330,6 +332,7 @@ netcdf_variables:
 #     long_name:    Downwelling irradiance value of the 532 nm wavelength
 #     standard_name: 532nm_downwelling_irradiance
 #     units:       W m-2 nm-1
+    average_method: "geometric mean"
 #     coordinates:   time depth latitude longitude
 #     instrument:    instrument_radiometer
 #     observation_type: "measured"
@@ -339,6 +342,7 @@ netcdf_variables:
 #     long_name:    Downwelling PAR (Photosynthetically Active Radiation) in range 400-700 nm
 #     standard_name: downwelling_PAR
 #     units:        μE m-2 s-1
+    average_method: "geometric mean"
 #     coordinates:   time depth latitude longitude
 #     instrument:    instrument_radiometer
 #     observation_type: "measured"

--- a/mission_yaml/SEA55_M37.yml
+++ b/mission_yaml/SEA55_M37.yml
@@ -312,6 +312,7 @@ netcdf_variables:
 #     long_name:    Downwelling irradiance value of the 380 nm wavelength
 #     standard_name: 380nm_downwelling_irradiance
 #     units:        W m-2 nm-1
+    average_method: "geometric mean"
 #     coordinates:   time depth latitude longitude
 #     instrument:    instrument_radiometer
 #     observation_type: "measured"
@@ -321,6 +322,7 @@ netcdf_variables:
 #     long_name:    Downwelling irradiance value of the 490 nm wavelength
 #     standard_name: 490nm_downwelling_irradiance
 #     units:        W m-2 nm-1
+    average_method: "geometric mean"
 #     coordinates:   time depth latitude longitude
 #     instrument:    instrument_radiometer
 #     observation_type: "measured"
@@ -330,6 +332,7 @@ netcdf_variables:
 #     long_name:    Downwelling irradiance value of the 532 nm wavelength
 #     standard_name: 532nm_downwelling_irradiance
 #     units:       W m-2 nm-1
+    average_method: "geometric mean"
 #     coordinates:   time depth latitude longitude
 #     instrument:    instrument_radiometer
 #     observation_type: "measured"
@@ -339,6 +342,7 @@ netcdf_variables:
 #     long_name:    Downwelling PAR (Photosynthetically Active Radiation) in range 400-700 nm
 #     standard_name: downwelling_PAR
 #     units:        μE m-2 s-1
+    average_method: "geometric mean"
 #     coordinates:   time depth latitude longitude
 #     instrument:    instrument_radiometer
 #     observation_type: "measured"

--- a/mission_yaml/SEA55_M39.yml
+++ b/mission_yaml/SEA55_M39.yml
@@ -313,6 +313,7 @@ netcdf_variables:
 #     long_name:    Downwelling irradiance value of the 380 nm wavelength
 #     standard_name: 380nm_downwelling_irradiance
 #     units:        W m-2 nm-1
+    average_method: "geometric mean"
 #     coordinates:   time depth latitude longitude
 #     instrument:    instrument_radiometer
 #     observation_type: "measured"
@@ -322,6 +323,7 @@ netcdf_variables:
 #     long_name:    Downwelling irradiance value of the 490 nm wavelength
 #     standard_name: 490nm_downwelling_irradiance
 #     units:        W m-2 nm-1
+    average_method: "geometric mean"
 #     coordinates:   time depth latitude longitude
 #     instrument:    instrument_radiometer
 #     observation_type: "measured"
@@ -331,6 +333,7 @@ netcdf_variables:
 #     long_name:    Downwelling irradiance value of the 532 nm wavelength
 #     standard_name: 532nm_downwelling_irradiance
 #     units:       W m-2 nm-1
+    average_method: "geometric mean"
 #     coordinates:   time depth latitude longitude
 #     instrument:    instrument_radiometer
 #     observation_type: "measured"
@@ -340,6 +343,7 @@ netcdf_variables:
 #     long_name:    Downwelling PAR (Photosynthetically Active Radiation) in range 400-700 nm
 #     standard_name: downwelling_PAR
 #     units:        μE m-2 s-1
+    average_method: "geometric mean"
 #     coordinates:   time depth latitude longitude
 #     instrument:    instrument_radiometer
 #     observation_type: "measured"

--- a/mission_yaml/SEA61_M38.yml
+++ b/mission_yaml/SEA61_M38.yml
@@ -312,6 +312,7 @@ netcdf_variables:
     long_name:    Downwelling irradiance value of the 380 nm wavelength
     standard_name: 380nm_downwelling_irradiance
     units:        W m-2 nm-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"
@@ -321,6 +322,7 @@ netcdf_variables:
     long_name:    Downwelling irradiance value of the 490 nm wavelength
     standard_name: 490nm_downwelling_irradiance
     units:        W m-2 nm-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"
@@ -330,6 +332,7 @@ netcdf_variables:
     long_name:    Downwelling irradiance value of the 532 nm wavelength
     standard_name: 532nm_downwelling_irradiance
     units:       W m-2 nm-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"
@@ -339,6 +342,7 @@ netcdf_variables:
     long_name:    Downwelling PAR (Photosynthetically Active Radiation) in range 400-700 nm
     standard_name: downwelling_PAR
     units:        μE m-2 s-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"

--- a/mission_yaml/SEA61_M39.yml
+++ b/mission_yaml/SEA61_M39.yml
@@ -312,6 +312,7 @@ netcdf_variables:
     long_name:    Downwelling irradiance value of the 380 nm wavelength
     standard_name: 380nm_downwelling_irradiance
     units:        W m-2 nm-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"
@@ -321,6 +322,7 @@ netcdf_variables:
     long_name:    Downwelling irradiance value of the 490 nm wavelength
     standard_name: 490nm_downwelling_irradiance
     units:        W m-2 nm-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"
@@ -330,6 +332,7 @@ netcdf_variables:
     long_name:    Downwelling irradiance value of the 532 nm wavelength
     standard_name: 532nm_downwelling_irradiance
     units:       W m-2 nm-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"
@@ -339,6 +342,7 @@ netcdf_variables:
     long_name:    Downwelling PAR (Photosynthetically Active Radiation) in range 400-700 nm
     standard_name: downwelling_PAR
     units:        μE m-2 s-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"

--- a/mission_yaml/SEA61_M40.yml
+++ b/mission_yaml/SEA61_M40.yml
@@ -312,6 +312,7 @@ netcdf_variables:
     long_name:    Downwelling irradiance value of the 380 nm wavelength
     standard_name: 380nm_downwelling_irradiance
     units:        W m-2 nm-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"
@@ -321,6 +322,7 @@ netcdf_variables:
     long_name:    Downwelling irradiance value of the 490 nm wavelength
     standard_name: 490nm_downwelling_irradiance
     units:        W m-2 nm-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"
@@ -330,6 +332,7 @@ netcdf_variables:
     long_name:    Downwelling irradiance value of the 532 nm wavelength
     standard_name: 532nm_downwelling_irradiance
     units:       W m-2 nm-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"
@@ -339,6 +342,7 @@ netcdf_variables:
     long_name:    Downwelling PAR (Photosynthetically Active Radiation) in range 400-700 nm
     standard_name: downwelling_PAR
     units:        μE m-2 s-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"

--- a/mission_yaml/SEA61_M42.yml
+++ b/mission_yaml/SEA61_M42.yml
@@ -312,6 +312,7 @@ netcdf_variables:
     long_name:    Downwelling irradiance value of the 380 nm wavelength
     standard_name: 380nm_downwelling_irradiance
     units:        W m-2 nm-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"
@@ -321,6 +322,7 @@ netcdf_variables:
     long_name:    Downwelling irradiance value of the 490 nm wavelength
     standard_name: 490nm_downwelling_irradiance
     units:        W m-2 nm-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"
@@ -330,6 +332,7 @@ netcdf_variables:
     long_name:    Downwelling irradiance value of the 532 nm wavelength
     standard_name: 532nm_downwelling_irradiance
     units:       W m-2 nm-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"
@@ -339,6 +342,7 @@ netcdf_variables:
     long_name:    Downwelling PAR (Photosynthetically Active Radiation) in range 400-700 nm
     standard_name: downwelling_PAR
     units:        μE m-2 s-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"

--- a/mission_yaml/SEA61_M43.yml
+++ b/mission_yaml/SEA61_M43.yml
@@ -312,6 +312,7 @@ netcdf_variables:
     long_name:    Downwelling irradiance value of the 380 nm wavelength
     standard_name: 380nm_downwelling_irradiance
     units:        W m-2 nm-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"
@@ -321,6 +322,7 @@ netcdf_variables:
     long_name:    Downwelling irradiance value of the 490 nm wavelength
     standard_name: 490nm_downwelling_irradiance
     units:        W m-2 nm-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"
@@ -330,6 +332,7 @@ netcdf_variables:
     long_name:    Downwelling irradiance value of the 532 nm wavelength
     standard_name: 532nm_downwelling_irradiance
     units:       W m-2 nm-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"
@@ -339,6 +342,7 @@ netcdf_variables:
     long_name:    Downwelling PAR (Photosynthetically Active Radiation) in range 400-700 nm
     standard_name: downwelling_PAR
     units:        μE m-2 s-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"

--- a/mission_yaml/SEA61_M45.yml
+++ b/mission_yaml/SEA61_M45.yml
@@ -312,6 +312,7 @@ netcdf_variables:
     long_name:    Downwelling irradiance value of the 380 nm wavelength
     standard_name: 380nm_downwelling_irradiance
     units:        W m-2 nm-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"
@@ -321,6 +322,7 @@ netcdf_variables:
     long_name:    Downwelling irradiance value of the 490 nm wavelength
     standard_name: 490nm_downwelling_irradiance
     units:        W m-2 nm-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"
@@ -330,6 +332,7 @@ netcdf_variables:
     long_name:    Downwelling irradiance value of the 532 nm wavelength
     standard_name: 532nm_downwelling_irradiance
     units:       W m-2 nm-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"
@@ -339,6 +342,7 @@ netcdf_variables:
     long_name:    Downwelling PAR (Photosynthetically Active Radiation) in range 400-700 nm
     standard_name: downwelling_PAR
     units:        μE m-2 s-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"

--- a/mission_yaml/SEA61_M48.yml
+++ b/mission_yaml/SEA61_M48.yml
@@ -312,6 +312,7 @@ netcdf_variables:
     long_name:    Downwelling irradiance value of the 380 nm wavelength
     standard_name: 380nm_downwelling_irradiance
     units:        W m-2 nm-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"
@@ -321,6 +322,7 @@ netcdf_variables:
     long_name:    Downwelling irradiance value of the 490 nm wavelength
     standard_name: 490nm_downwelling_irradiance
     units:        W m-2 nm-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"
@@ -330,6 +332,7 @@ netcdf_variables:
     long_name:    Downwelling irradiance value of the 532 nm wavelength
     standard_name: 532nm_downwelling_irradiance
     units:       W m-2 nm-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"
@@ -339,6 +342,7 @@ netcdf_variables:
     long_name:    Downwelling PAR (Photosynthetically Active Radiation) in range 400-700 nm
     standard_name: downwelling_PAR
     units:        μE m-2 s-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"

--- a/mission_yaml/SEA61_M50.yml
+++ b/mission_yaml/SEA61_M50.yml
@@ -312,6 +312,7 @@ netcdf_variables:
     long_name:    Downwelling irradiance value of the 380 nm wavelength
     standard_name: 380nm_downwelling_irradiance
     units:        W m-2 nm-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"
@@ -321,6 +322,7 @@ netcdf_variables:
     long_name:    Downwelling irradiance value of the 490 nm wavelength
     standard_name: 490nm_downwelling_irradiance
     units:        W m-2 nm-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"
@@ -330,6 +332,7 @@ netcdf_variables:
     long_name:    Downwelling irradiance value of the 532 nm wavelength
     standard_name: 532nm_downwelling_irradiance
     units:       W m-2 nm-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"
@@ -339,6 +342,7 @@ netcdf_variables:
     long_name:    Downwelling PAR (Photosynthetically Active Radiation) in range 400-700 nm
     standard_name: downwelling_PAR
     units:        μE m-2 s-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"

--- a/mission_yaml/SEA61_M54.yml
+++ b/mission_yaml/SEA61_M54.yml
@@ -312,6 +312,7 @@ netcdf_variables:
 #     long_name:    Downwelling irradiance value of the 380 nm wavelength
 #     standard_name: 380nm_downwelling_irradiance
 #     units:        W m-2 nm-1
+    average_method: "geometric mean"
 #     coordinates:   time depth latitude longitude
 #     instrument:    instrument_radiometer
 #     observation_type: "measured"
@@ -321,6 +322,7 @@ netcdf_variables:
 #     long_name:    Downwelling irradiance value of the 490 nm wavelength
 #     standard_name: 490nm_downwelling_irradiance
 #     units:        W m-2 nm-1
+    average_method: "geometric mean"
 #     coordinates:   time depth latitude longitude
 #     instrument:    instrument_radiometer
 #     observation_type: "measured"
@@ -330,6 +332,7 @@ netcdf_variables:
 #     long_name:    Downwelling irradiance value of the 532 nm wavelength
 #     standard_name: 532nm_downwelling_irradiance
 #     units:       W m-2 nm-1
+    average_method: "geometric mean"
 #     coordinates:   time depth latitude longitude
 #     instrument:    instrument_radiometer
 #     observation_type: "measured"
@@ -339,6 +342,7 @@ netcdf_variables:
 #     long_name:    Downwelling PAR (Photosynthetically Active Radiation) in range 400-700 nm
 #     standard_name: downwelling_PAR
 #     units:        μE m-2 s-1
+    average_method: "geometric mean"
 #     coordinates:   time depth latitude longitude
 #     instrument:    instrument_radiometer
 #     observation_type: "measured"

--- a/mission_yaml/SEA61_M56.yml
+++ b/mission_yaml/SEA61_M56.yml
@@ -312,6 +312,7 @@ netcdf_variables:
 #     long_name:    Downwelling irradiance value of the 380 nm wavelength
 #     standard_name: 380nm_downwelling_irradiance
 #     units:        W m-2 nm-1
+    average_method: "geometric mean"
 #     coordinates:   time depth latitude longitude
 #     instrument:    instrument_radiometer
 #     observation_type: "measured"
@@ -321,6 +322,7 @@ netcdf_variables:
 #     long_name:    Downwelling irradiance value of the 490 nm wavelength
 #     standard_name: 490nm_downwelling_irradiance
 #     units:        W m-2 nm-1
+    average_method: "geometric mean"
 #     coordinates:   time depth latitude longitude
 #     instrument:    instrument_radiometer
 #     observation_type: "measured"
@@ -330,6 +332,7 @@ netcdf_variables:
 #     long_name:    Downwelling irradiance value of the 532 nm wavelength
 #     standard_name: 532nm_downwelling_irradiance
 #     units:       W m-2 nm-1
+    average_method: "geometric mean"
 #     coordinates:   time depth latitude longitude
 #     instrument:    instrument_radiometer
 #     observation_type: "measured"
@@ -339,6 +342,7 @@ netcdf_variables:
 #     long_name:    Downwelling PAR (Photosynthetically Active Radiation) in range 400-700 nm
 #     standard_name: downwelling_PAR
 #     units:        μE m-2 s-1
+    average_method: "geometric mean"
 #     coordinates:   time depth latitude longitude
 #     instrument:    instrument_radiometer
 #     observation_type: "measured"

--- a/mission_yaml/SEA61_M57.yml
+++ b/mission_yaml/SEA61_M57.yml
@@ -312,6 +312,7 @@ netcdf_variables:
 #     long_name:    Downwelling irradiance value of the 380 nm wavelength
 #     standard_name: 380nm_downwelling_irradiance
 #     units:        W m-2 nm-1
+    average_method: "geometric mean"
 #     coordinates:   time depth latitude longitude
 #     instrument:    instrument_radiometer
 #     observation_type: "measured"
@@ -321,6 +322,7 @@ netcdf_variables:
 #     long_name:    Downwelling irradiance value of the 490 nm wavelength
 #     standard_name: 490nm_downwelling_irradiance
 #     units:        W m-2 nm-1
+    average_method: "geometric mean"
 #     coordinates:   time depth latitude longitude
 #     instrument:    instrument_radiometer
 #     observation_type: "measured"
@@ -330,6 +332,7 @@ netcdf_variables:
 #     long_name:    Downwelling irradiance value of the 532 nm wavelength
 #     standard_name: 532nm_downwelling_irradiance
 #     units:       W m-2 nm-1
+    average_method: "geometric mean"
 #     coordinates:   time depth latitude longitude
 #     instrument:    instrument_radiometer
 #     observation_type: "measured"
@@ -339,6 +342,7 @@ netcdf_variables:
 #     long_name:    Downwelling PAR (Photosynthetically Active Radiation) in range 400-700 nm
 #     standard_name: downwelling_PAR
 #     units:        μE m-2 s-1
+    average_method: "geometric mean"
 #     coordinates:   time depth latitude longitude
 #     instrument:    instrument_radiometer
 #     observation_type: "measured"

--- a/mission_yaml/SEA66_M10.yml
+++ b/mission_yaml/SEA66_M10.yml
@@ -323,6 +323,7 @@ netcdf_variables:
     long_name:    Downwelling irradiance value of the 380 nm wavelength
     standard_name: 380nm_downwelling_irradiance
     units:        W m-2 nm-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"
@@ -332,6 +333,7 @@ netcdf_variables:
     long_name:    Downwelling irradiance value of the 490 nm wavelength
     standard_name: 490nm_downwelling_irradiance
     units:        W m-2 nm-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"
@@ -341,6 +343,7 @@ netcdf_variables:
     long_name:    Downwelling irradiance value of the 532 nm wavelength
     standard_name: 532nm_downwelling_irradiance
     units:       W m-2 nm-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"
@@ -350,6 +353,7 @@ netcdf_variables:
     long_name:    Downwelling PAR (Photosynthetically Active Radiation) in range 400-700 nm
     standard_name: downwelling_PAR
     units:        μE m-2 s-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"

--- a/mission_yaml/SEA66_M12.yml
+++ b/mission_yaml/SEA66_M12.yml
@@ -323,6 +323,7 @@ netcdf_variables:
     long_name:    Downwelling irradiance value of the 380 nm wavelength
     standard_name: 380nm_downwelling_irradiance
     units:        W m-2 nm-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"
@@ -332,6 +333,7 @@ netcdf_variables:
     long_name:    Downwelling irradiance value of the 490 nm wavelength
     standard_name: 490nm_downwelling_irradiance
     units:        W m-2 nm-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"
@@ -341,6 +343,7 @@ netcdf_variables:
     long_name:    Downwelling irradiance value of the 532 nm wavelength
     standard_name: 532nm_downwelling_irradiance
     units:       W m-2 nm-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"
@@ -350,6 +353,7 @@ netcdf_variables:
     long_name:    Downwelling PAR (Photosynthetically Active Radiation) in range 400-700 nm
     standard_name: downwelling_PAR
     units:        μE m-2 s-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"

--- a/mission_yaml/SEA66_M14.yml
+++ b/mission_yaml/SEA66_M14.yml
@@ -323,6 +323,7 @@ netcdf_variables:
     long_name:    Downwelling irradiance value of the 380 nm wavelength
     standard_name: 380nm_downwelling_irradiance
     units:        W m-2 nm-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"
@@ -332,6 +333,7 @@ netcdf_variables:
     long_name:    Downwelling irradiance value of the 490 nm wavelength
     standard_name: 490nm_downwelling_irradiance
     units:        W m-2 nm-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"
@@ -341,6 +343,7 @@ netcdf_variables:
     long_name:    Downwelling irradiance value of the 532 nm wavelength
     standard_name: 532nm_downwelling_irradiance
     units:       W m-2 nm-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"
@@ -350,6 +353,7 @@ netcdf_variables:
     long_name:    Downwelling PAR (Photosynthetically Active Radiation) in range 400-700 nm
     standard_name: downwelling_PAR
     units:        μE m-2 s-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"

--- a/mission_yaml/SEA66_M16.yml
+++ b/mission_yaml/SEA66_M16.yml
@@ -323,6 +323,7 @@ netcdf_variables:
     long_name:    Downwelling irradiance value of the 380 nm wavelength
     standard_name: 380nm_downwelling_irradiance
     units:        W m-2 nm-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"
@@ -332,6 +333,7 @@ netcdf_variables:
     long_name:    Downwelling irradiance value of the 490 nm wavelength
     standard_name: 490nm_downwelling_irradiance
     units:        W m-2 nm-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"
@@ -341,6 +343,7 @@ netcdf_variables:
     long_name:    Downwelling irradiance value of the 532 nm wavelength
     standard_name: 532nm_downwelling_irradiance
     units:       W m-2 nm-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"
@@ -350,6 +353,7 @@ netcdf_variables:
     long_name:    Downwelling PAR (Photosynthetically Active Radiation) in range 400-700 nm
     standard_name: downwelling_PAR
     units:        μE m-2 s-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"

--- a/mission_yaml/SEA67_M15.yml
+++ b/mission_yaml/SEA67_M15.yml
@@ -323,6 +323,7 @@ netcdf_variables:
     long_name:    Downwelling irradiance value of the 380 nm wavelength
     standard_name: 380nm_downwelling_irradiance
     units:        W m-2 nm-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"
@@ -332,6 +333,7 @@ netcdf_variables:
     long_name:    Downwelling irradiance value of the 490 nm wavelength
     standard_name: 490nm_downwelling_irradiance
     units:        W m-2 nm-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"
@@ -341,6 +343,7 @@ netcdf_variables:
     long_name:    Downwelling irradiance value of the 532 nm wavelength
     standard_name: 532nm_downwelling_irradiance
     units:       W m-2 nm-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"
@@ -350,6 +353,7 @@ netcdf_variables:
     long_name:    Downwelling PAR (Photosynthetically Active Radiation) in range 400-700 nm
     standard_name: downwelling_PAR
     units:        μE m-2 s-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"

--- a/variables.yaml
+++ b/variables.yaml
@@ -351,6 +351,7 @@ netcdf_variables:
     long_name:    Downwelling irradiance value of the 380 nm wavelength
     standard_name: 380nm_downwelling_irradiance
     units:        W m-2 nm-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"
@@ -360,6 +361,7 @@ netcdf_variables:
     long_name:    Downwelling irradiance value of the 490 nm wavelength
     standard_name: 490nm_downwelling_irradiance
     units:        W m-2 nm-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"
@@ -369,6 +371,7 @@ netcdf_variables:
     long_name:    Downwelling irradiance value of the 532 nm wavelength
     standard_name: 532nm_downwelling_irradiance
     units:       W m-2 nm-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"
@@ -378,6 +381,7 @@ netcdf_variables:
     long_name:    Downwelling PAR (Photosynthetically Active Radiation) in range 400-700 nm
     standard_name: downwelling_PAR
     units:        μE m-2 s-1
+    average_method: "geometric mean"
     coordinates:   time depth latitude longitude
     instrument:    instrument_radiometer
     observation_type: "measured"

--- a/yaml_checker.py
+++ b/yaml_checker.py
@@ -148,6 +148,13 @@ def check_strings(d, _log):
 def check_variables(variables, _log):
     if 'ad2cp_altitude' in variables.keys():
         _log.error('ad2cp_altitude found in variables. We are not currently distributing altitude data. Please remove')
+    for name in variables.keys():
+        if name in ["keep_variables", "timebase"]:
+            continue
+        var = variables[name]
+        if "irradiance" in var["long_name"] or "PAR" in var["long_name"]:
+            if var["average_method"] != "geometric mean":
+                _log.error(f"{name} avergage_method should be 'geometric mean'")
 
 if __name__ == '__main__':
     args = sys.argv


### PR DESCRIPTION
Following advice from Bastien, averages for all irradiance and PAR meausrements are to be calculated with the geometric mean rather than arithemetic mean.

This has been implemented in pyglider https://github.com/c-proof/pyglider/pull/59

This PR adds the requisite yml to apply this to all our PAR and irradiance data. It also has an added test in yaml checker.