### PR TITLE
add pilot-defined qc to sea70 mission 14 and 15

### DIFF
--- a/mission_yaml/SEA70_M14.yml
+++ b/mission_yaml/SEA70_M14.yml
@@ -607,3 +607,17 @@ profile_variables:
     platform:            platform
     serial_number:       "CTD0271"
     type:                platform
+qc:
+    conductivity:
+        value:  4
+        comment: ctd pump failed. Downcast data are less badly affected.
+        start: "2022-10-30"
+    temperature:
+        value:  4
+        comment: ctd pump failed. Downcast data are less badly affected.
+        start: "2022-10-30"
+    oxygen_frequency:
+        value:  4
+        comment: ctd pump failed. Downcast data are less badly affected.
+        start: "2022-10-30"
+

--- a/mission_yaml/SEA70_M15.yml
+++ b/mission_yaml/SEA70_M15.yml
@@ -607,3 +607,14 @@ profile_variables:
     platform:            platform
     serial_number:       "CTD0271"
     type:                platform
+
+qc:
+    conductivity:
+        value:  4
+        comment: ctd pump failed. Downcast data are less badly affected.
+    temperature:
+        value:  4
+        comment: ctd pump failed. Downcast data are less badly affected.
+    oxygen_frequency:
+        value:  4
+        comment: ctd pump failed. Downcast data are less badly affected.

--- a/yaml_checker.py
+++ b/yaml_checker.py
@@ -122,7 +122,9 @@ def check_qc(deployment, _log):
         if qc_var not in variables:
             _log.error(f"qc variable {qc_var} not present in netcdf variables")
         if qc_dict["value"] not in [1, 2, 3, 4, 9]:
-            _log.error(f"qc var {qc_var}  value {qc_dict['value']} invlaid. Must be in [1, 2, 3, 4, 9]")
+            _log.error(f"qc var {qc_var}  value {qc_dict['value']} invalid. Must be in [1, 2, 3, 4, 9]")
+        if "comment" not in qc_dict.keys():
+            _log.error(f"qc var {qc_var} has no comment")
         if "start" in qc_dict.keys():
             _log.info('Checking qc start')
             start = qc_dict['start']

--- a/yaml_checker.py
+++ b/yaml_checker.py
@@ -109,7 +109,38 @@ def check_yaml(yaml_path, check_urls=False, log_level='INFO'):
     check_against_meta(meta, _log)
     check_keep_variables(deployment, _log)
     check_variables(deployment['netcdf_variables'], _log)
+    check_qc(deployment, _log)
 
+
+def check_qc(deployment, _log):
+    if "qc" not in deployment.keys():
+        return
+    _log.info("Check qc")
+    variables = deployment['netcdf_variables']
+    qc_items = deployment["qc"]
+    for qc_var, qc_dict in qc_items.items():
+        if qc_var not in variables:
+            _log.error(f"qc variable {qc_var} not present in netcdf variables")
+        if qc_dict["value"] not in [1, 2, 3, 4, 9]:
+            _log.error(f"qc var {qc_var}  value {qc_dict['value']} invlaid. Must be in [1, 2, 3, 4, 9]")
+        if "start" in qc_dict.keys():
+            _log.info('Checking qc start')
+            start = qc_dict['start']
+            try:
+                start_time = datetime.strptime(start, "%Y-%m-%d")
+            except ValueError:
+                _log.error(f'qc {qc_var} {start} incorrectly formatted. Should be YYYY-MM-DD')
+        if "end" in qc_dict.keys():
+            end =qc_dict['end']
+            try:
+                end_time = datetime.strptime(end, "%Y-%m-%d")
+            except ValueError:
+                _log.error(f'qc {qc_var} {end} incorrectly formatted. Should be YYYY-MM-DD')
+        if "start" in qc_dict.keys() and "end" in qc_dict.keys():
+                deployment_duration = end_time - start_time
+                if deployment_duration < timedelta(0):
+                    _log.error(f'qc {qc_var} end is sooner than start')
+    
 
 def check_against_meta(deployment_meta, _log):
     _log.info('Checking against meta.yaml')


### PR DESCRIPTION
@MOchiara @MartinMohrmann this PR shows the proposed method for us to apply manual QC that overrides the automated routines. I've used SEA070 missions 14 and 15 as an example. The pump on the GPCTD failed. The `qc` block at the end of the yaml should serve as a template for future efforts. Mission 15 shows the minimum requirements: a qc value and a comment explaining it. 

The manual qc value will be set to 3 if data are suspect, or 4 if they are bad, as in this case.

Note how in mission 14 we have a start date for the failure, so the good CTD data from before the pump failure will not be flagged.