### PR TITLE
Check that all sensor serial numbers are strings

### DIFF
--- a/mission_yaml/SEA63_M71.yml
+++ b/mission_yaml/SEA63_M71.yml
@@ -68,7 +68,7 @@ glider_devices:
   oxygen:
     make: JFE Advantech
     model: AROD-FT
-    serial: 0040
+    serial: '0040'
     long_name: JFE Advantech RINKO-FT
     make_model: JFE Advantech AROD_FT
     factory_calibrated: 'Yes'

--- a/mission_yaml/SEA63_M72.yml
+++ b/mission_yaml/SEA63_M72.yml
@@ -67,7 +67,7 @@ glider_devices:
   oxygen:
     make: JFE Advantech
     model: AROD-FT
-    serial: 0040
+    serial: '0040'
     long_name: JFE Advantech RINKO-FT
     make_model: JFE Advantech AROD_FT
     factory_calibrated: 'Yes'

--- a/mission_yaml/SEA63_M73.yml
+++ b/mission_yaml/SEA63_M73.yml
@@ -67,7 +67,7 @@ glider_devices:
   oxygen:
     make: JFE Advantech
     model: AROD-FT
-    serial: 0040
+    serial: '0040'
     long_name: JFE Advantech RINKO-FT
     make_model: JFE Advantech AROD_FT
     factory_calibrated: 'Yes'

--- a/mission_yaml/SEA63_M74.yml
+++ b/mission_yaml/SEA63_M74.yml
@@ -67,7 +67,7 @@ glider_devices:
   oxygen:
     make: JFE Advantech
     model: AROD-FT
-    serial: 0040
+    serial: '0040'
     long_name: JFE Advantech RINKO-FT
     make_model: JFE Advantech AROD_FT
     factory_calibrated: 'Yes'

--- a/mission_yaml/SEA67_M55.yml
+++ b/mission_yaml/SEA67_M55.yml
@@ -70,7 +70,7 @@ glider_devices:
   oxygen:
     make: JFE Advantech
     model: AROD-FT
-    serial: 0041
+    serial: '0041'
     long_name: JFE Advantech RINKO-FT
     make_model: JFE Advantech AROD_FT
     factory_calibrated: 'Yes'

--- a/mission_yaml/SEA67_M56.yml
+++ b/mission_yaml/SEA67_M56.yml
@@ -69,7 +69,7 @@ glider_devices:
   oxygen:
     make: JFE Advantech
     model: AROD-FT
-    serial: 0041
+    serial: '0041'
     long_name: JFE Advantech RINKO-FT
     make_model: JFE Advantech AROD_FT
     factory_calibrated: 'Yes'

--- a/mission_yaml/SEA67_M58.yml
+++ b/mission_yaml/SEA67_M58.yml
@@ -69,7 +69,7 @@ glider_devices:
   oxygen:
     make: JFE Advantech
     model: AROD-FT
-    serial: 0041
+    serial: '0041'
     long_name: JFE Advantech RINKO-FT
     make_model: JFE Advantech AROD_FT
     factory_calibrated: 'Yes'

--- a/mission_yaml/SEA67_M59.yml
+++ b/mission_yaml/SEA67_M59.yml
@@ -69,7 +69,7 @@ glider_devices:
   oxygen:
     make: JFE Advantech
     model: AROD-FT
-    serial: 0041
+    serial: '0041'
     long_name: JFE Advantech RINKO-FT
     make_model: JFE Advantech AROD_FT
     factory_calibrated: 'Yes'

--- a/mission_yaml/SEA78_M24.yml
+++ b/mission_yaml/SEA78_M24.yml
@@ -69,7 +69,7 @@ glider_devices:
   oxygen:
     make: JFE Advantech
     model: AROD-FT
-    serial: 0071
+    serial: '0071'
     long_name: JFE Advantech RINKO-FT
     make_model: JFE Advantech AROD_FT
     factory_calibrated: 'Yes'

--- a/mission_yaml/SEA78_M25.yml
+++ b/mission_yaml/SEA78_M25.yml
@@ -69,7 +69,7 @@ glider_devices:
   oxygen:
     make: JFE Advantech
     model: AROD-FT
-    serial: 0071
+    serial: '0071'
     long_name: JFE Advantech RINKO-FT
     make_model: JFE Advantech AROD_FT
     factory_calibrated: 'Yes'

--- a/yaml_checker.py
+++ b/yaml_checker.py
@@ -40,7 +40,6 @@ def check_yaml(yaml_path, check_urls=False, log_level='INFO'):
                      'deployment_name', 'project', 'project_url', 'summary',
                      'sea_name')
 
-
     for key in metadata_keys:
         if key not in deployment['metadata'].keys():
             _log.error(f'{key} not found in metadata')
@@ -88,6 +87,7 @@ def check_yaml(yaml_path, check_urls=False, log_level='INFO'):
     check_keep_variables(deployment, _log)
     check_variables(deployment['netcdf_variables'], _log)
     check_qc(deployment, _log)
+    check_sensor_serials(deployment['glider_devices'], _log)
 
 
 def check_qc(deployment, _log):
@@ -174,6 +174,13 @@ def check_variables(variables, _log):
         if "irradiance" in var["long_name"] or "PAR" in var["long_name"]:
             if var["average_method"] != "geometric mean":
                 _log.error(f"{name} avergage_method should be 'geometric mean'")
+
+
+def check_sensor_serials(sensors, _log):
+    for sensor, attrs in sensors.items():
+        if type(attrs['serial']) is not str:
+            _log.error(f"{sensor} serial number must be a string")
+
 
 if __name__ == '__main__':
     args = sys.argv

--- a/yaml_checker.py
+++ b/yaml_checker.py
@@ -179,7 +179,7 @@ def check_variables(variables, _log):
 def check_sensor_serials(sensors, _log):
     for sensor, attrs in sensors.items():
         if type(attrs['serial']) is not str:
-            _log.error(f"{sensor} serial number must be a string")
+            _log.error(f"type of {sensor} serial number must be a string. It is {type(attrs['serial'])}")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This should cause the tests to fail, as at least one mission has a sensor with an int serial number